### PR TITLE
support non-root urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typesense",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Javascript Library for Typesense",
   "homepage": "https://github.com/typesense/typesense-js",
   "author": {

--- a/src/Typesense/ApiCall.js
+++ b/src/Typesense/ApiCall.js
@@ -3,6 +3,17 @@ import axios from 'axios'
 
 const APIKEYHEADERNAME = 'X-TYPESENSE-API-KEY'
 
+const buildLocationUrl = function(host, port) {
+  // if the host is a non-root URL, such as example.com/typesense
+  // then the port number cannot be appended, as example.com/typesense:8108
+  // instead it must be example.com:8108/typesense
+  let hostFragments = host.split("/");
+  if (hostFragments.length > 1) {
+    hostFragments[0] = hostFragments[0] + `:${port}`
+    return hostFragments.join("/")
+  }
+  return `${host}:${port}`
+}
 class ApiCall {
   constructor (configuration) {
     this._configuration = configuration
@@ -12,9 +23,9 @@ class ApiCall {
 
   _uriFor (endpoint, node = this._defaultNode, nodeIndex = this._defaultNodeIndex) {
     if (node === 'readReplica') {
-      return `${this._configuration.readReplicaNodes[nodeIndex].protocol}://${this._configuration.readReplicaNodes[nodeIndex].host}:${this._configuration.readReplicaNodes[nodeIndex].port}${endpoint}`
+      return `${this._configuration.readReplicaNodes[nodeIndex].protocol}://${buildLocationUrl(this._configuration.readReplicaNodes[nodeIndex].host, this._configuration.readReplicaNodes[nodeIndex].port)}${endpoint}`
     } else {
-      return `${this._configuration.masterNode.protocol}://${this._configuration.masterNode.host}:${this._configuration.masterNode.port}${endpoint}`
+      return `${this._configuration.masterNode.protocol}://${buildLocationUrl(this._configuration.masterNode.host, this._configuration.masterNode.port)}${endpoint}`
     }
   }
 


### PR DESCRIPTION
This change allows the uriFor to properly construct the url and port, given typesense is running on a non-root location.