### PR TITLE
Add cancellability to search requests.

### DIFF
--- a/src/Typesense/ApiCall.js
+++ b/src/Typesense/ApiCall.js
@@ -59,7 +59,6 @@ export default class ApiCall {
     additionalHeaders = {},
     signal = null
   }) {
-
     this
       ._configuration
       .validate()
@@ -70,11 +69,11 @@ export default class ApiCall {
     for (let numTries = 1; numTries <= this._numRetriesPerRequest + 1; numTries++) {
       let node = this._getNextNode(requestNumber)
       this.logger.debug(`Request #${requestNumber}: Attempting ${requestType.toUpperCase()} request Try #${numTries} to Node ${node.index}`)
-      
+
       if (signal && signal.aborted) {
-        return Promise.reject('Request aborted by caller.')
+        return Promise.reject(new Error('Request aborted by caller.'))
       }
-      let abortListener;
+      let abortListener
 
       try {
         let requestOptions = {

--- a/src/Typesense/ApiCall.js
+++ b/src/Typesense/ApiCall.js
@@ -33,8 +33,8 @@ export default class ApiCall {
     this._currentNodeIndex = -1
   }
 
-  get (endpoint, queryParameters = {}) {
-    return this.performRequest('get', endpoint, {queryParameters})
+  get (endpoint, queryParameters = {}, {signal = null}) {
+    return this.performRequest('get', endpoint, {queryParameters, signal})
   }
 
   delete (endpoint, queryParameters = {}) {
@@ -56,8 +56,10 @@ export default class ApiCall {
   async performRequest (requestType, endpoint, {
     queryParameters = null,
     bodyParameters = null,
-    additionalHeaders = {}
+    additionalHeaders = {},
+    signal = null
   }) {
+
     this
       ._configuration
       .validate()
@@ -68,6 +70,12 @@ export default class ApiCall {
     for (let numTries = 1; numTries <= this._numRetriesPerRequest + 1; numTries++) {
       let node = this._getNextNode(requestNumber)
       this.logger.debug(`Request #${requestNumber}: Attempting ${requestType.toUpperCase()} request Try #${numTries} to Node ${node.index}`)
+      
+      if (signal && signal.aborted) {
+        return Promise.reject('Request aborted by caller.')
+      }
+      let abortListener;
+
       try {
         let requestOptions = {
           method: requestType,
@@ -105,6 +113,15 @@ export default class ApiCall {
           requestOptions.data = bodyParameters
         }
 
+        // Translate from user-provided AbortController to the Axios request cancel mechanism.
+        if (signal) {
+          const cancelToken = axios.CancelToken
+          const source = cancelToken.source()
+          abortListener = () => source.cancel()
+          signal.addEventListener('abort', abortListener)
+          requestOptions.cancelToken = source.token
+        }
+
         let response = await axios(requestOptions)
         if (response.status >= 1 && response.status <= 499) {
           // Treat any status code > 0 and < 500 to be an indication that node is healthy
@@ -132,6 +149,10 @@ export default class ApiCall {
         // this.logger.debug(error.stack)
         this.logger.warn(`Request #${requestNumber}: Sleeping for ${this._retryIntervalSeconds}s and then retrying request...`)
         await this._timer(this._retryIntervalSeconds)
+      } finally {
+        if (signal && abortListener) {
+          signal.removeEventListener('abort', abortListener)
+        }
       }
     }
     this.logger.debug(`Request #${requestNumber}: No retries left. Raising last error`)

--- a/src/Typesense/ApiCall.js
+++ b/src/Typesense/ApiCall.js
@@ -33,7 +33,7 @@ export default class ApiCall {
     this._currentNodeIndex = -1
   }
 
-  get (endpoint, queryParameters = {}, {signal = null}) {
+  get (endpoint, queryParameters = {}, {signal = null} = {}) {
     return this.performRequest('get', endpoint, {queryParameters, signal})
   }
 

--- a/src/Typesense/Documents.js
+++ b/src/Typesense/Documents.js
@@ -78,7 +78,7 @@ export default class Documents {
 
   search (searchParameters,
     {cacheSearchResultsForSeconds = this._configuration.cacheSearchResultsForSeconds} = {},
-    {signal = null}) {
+    {signal = null} = {}) {
     let additionalQueryParams = {}
     if (this._configuration.useServerSideSearchCache === true) {
       additionalQueryParams['use_cache'] = true

--- a/src/Typesense/Documents.js
+++ b/src/Typesense/Documents.js
@@ -76,9 +76,10 @@ export default class Documents {
     return this._apiCall.get(this._endpointPath('export'), options)
   }
 
-  search (searchParameters,
-    {cacheSearchResultsForSeconds = this._configuration.cacheSearchResultsForSeconds} = {},
-    {abortSignal = null} = {}) {
+  search (searchParameters, {
+    cacheSearchResultsForSeconds = this._configuration.cacheSearchResultsForSeconds,
+    abortSignal = null
+  } = {}) {
     let additionalQueryParams = {}
     if (this._configuration.useServerSideSearchCache === true) {
       additionalQueryParams['use_cache'] = true

--- a/src/Typesense/Documents.js
+++ b/src/Typesense/Documents.js
@@ -78,7 +78,7 @@ export default class Documents {
 
   search (searchParameters,
     {cacheSearchResultsForSeconds = this._configuration.cacheSearchResultsForSeconds} = {},
-    {signal = null} = {}) {
+    {abortSignal = null} = {}) {
     let additionalQueryParams = {}
     if (this._configuration.useServerSideSearchCache === true) {
       additionalQueryParams['use_cache'] = true
@@ -88,7 +88,7 @@ export default class Documents {
     return this._requestWithCache.perform(
       this._apiCall,
       this._apiCall.get,
-      [this._endpointPath('search'), queryParams, {signal}],
+      [this._endpointPath('search'), queryParams, {abortSignal}],
       {cacheResponseForSeconds: cacheSearchResultsForSeconds}
     )
   }

--- a/src/Typesense/Documents.js
+++ b/src/Typesense/Documents.js
@@ -76,9 +76,9 @@ export default class Documents {
     return this._apiCall.get(this._endpointPath('export'), options)
   }
 
-  search (searchParameters, 
+  search (searchParameters,
     {cacheSearchResultsForSeconds = this._configuration.cacheSearchResultsForSeconds} = {},
-    {signal = null}) {    
+    {signal = null}) {
     let additionalQueryParams = {}
     if (this._configuration.useServerSideSearchCache === true) {
       additionalQueryParams['use_cache'] = true

--- a/src/Typesense/Documents.js
+++ b/src/Typesense/Documents.js
@@ -76,7 +76,9 @@ export default class Documents {
     return this._apiCall.get(this._endpointPath('export'), options)
   }
 
-  search (searchParameters, {cacheSearchResultsForSeconds = this._configuration.cacheSearchResultsForSeconds} = {}) {
+  search (searchParameters, 
+    {cacheSearchResultsForSeconds = this._configuration.cacheSearchResultsForSeconds} = {},
+    {signal = null}) {    
     let additionalQueryParams = {}
     if (this._configuration.useServerSideSearchCache === true) {
       additionalQueryParams['use_cache'] = true
@@ -86,7 +88,7 @@ export default class Documents {
     return this._requestWithCache.perform(
       this._apiCall,
       this._apiCall.get,
-      [this._endpointPath('search'), queryParams],
+      [this._endpointPath('search'), queryParams, {signal}],
       {cacheResponseForSeconds: cacheSearchResultsForSeconds}
     )
   }


### PR DESCRIPTION
## Change Summary
Adds a user-provided AbortController parameter to the search function so that in-flight searches whose results have become obsolete may be cancelled before completing. 

See https://developer.mozilla.org/en-US/docs/Web/API/AbortController for motivation.


## PR Checklist
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
