### PR TITLE
fix: display error message if document has too many keys

### DIFF
--- a/src/Typesense/Documents.ts
+++ b/src/Typesense/Documents.ts
@@ -188,8 +188,19 @@ export default class Documents<T extends DocumentSchema = {}>
   async import(documents: T[], options?: DocumentWriteParameters): Promise<ImportResponse[]>
   async import(documents: T[] | string, options: DocumentWriteParameters = {}): Promise<string | ImportResponse[]> {
     let documentsInJSONLFormat
+
     if (Array.isArray(documents)) {
-      documentsInJSONLFormat = documents.map((document) => JSON.stringify(document)).join('\n')
+      try {
+        documentsInJSONLFormat = documents.map((document) => JSON.stringify(document)).join('\n')
+      } catch (error) {
+        if(RangeError instanceof error && error?.includes("Too many properties to enumerate")) {
+          throw new Error(`${error}
+          Hey There! It looks like you were passing too many keys into a single document. You are limited in the number of keys you can stringify from an Object depending on your specific JS environment: https://stackoverflow.com/questions/9282869/are-there-limits-to-the-number-of-properties-in-a-javascript-object
+
+          Why don't you try to reduce the number of keys you want to pass in and try again?
+          `)
+        }
+      }
     } else {
       documentsInJSONLFormat = documents
     }


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->

This PR fixes this issue: https://github.com/typesense/typesense-js/issues/81. The reported issue was that the incoming document stream had too many objects while parsing via `JSON.stringify`. Since we don't run `stringify` on the complete documents object, but just the individual document, this means the user was trying to pass in an object with a very large number of keys.

In case this error pops up in the future, an error message will be displayed with the proper StackOverflow link.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
