### PR TITLE
Create exportStream method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ typesense-server-nodes
 *.log
 .DS_Store
 test-results.xml
+test-files

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "typesense",
-      "version": "1.0.3-0",
+      "version": "1.0.3-2",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^0.21.1",

--- a/src/Typesense/ApiCall.ts
+++ b/src/Typesense/ApiCall.ts
@@ -62,7 +62,10 @@ export default class ApiCall {
   get<T extends any>(
     endpoint: string,
     queryParameters: any = {},
-    { abortSignal, responseType }: { abortSignal?: any; responseType?: AxiosRequestConfig['responseType'] } = {}
+    {
+      abortSignal = null,
+      responseType = null
+    }: { abortSignal?: any; responseType?: AxiosRequestConfig['responseType'] } = {}
   ): Promise<T> {
     return this.performRequest<T>('get', endpoint, { queryParameters, abortSignal, responseType })
   }

--- a/src/Typesense/ApiCall.ts
+++ b/src/Typesense/ApiCall.ts
@@ -20,14 +20,6 @@ interface Node extends NodeConfiguration {
   index: string | number
 }
 
-interface PerformRequestOptions {
-  queryParameters?: any
-  bodyParameters?: any
-  additionalHeaders?: any
-  abortSignal?: any
-  responseType?: AxiosRequestConfig['responseType']
-}
-
 export default class ApiCall {
   private readonly apiKey: string
   private readonly nodes: Node[]
@@ -100,7 +92,13 @@ export default class ApiCall {
       additionalHeaders = {},
       abortSignal = null,
       responseType = null
-    }: PerformRequestOptions
+    }: {
+      queryParameters?: any
+      bodyParameters?: any
+      additionalHeaders?: any
+      abortSignal?: any
+      responseType?: AxiosRequestConfig['responseType']
+    }
   ): Promise<T> {
     this.configuration.validate()
 

--- a/src/Typesense/ApiCall.ts
+++ b/src/Typesense/ApiCall.ts
@@ -20,6 +20,14 @@ interface Node extends NodeConfiguration {
   index: string | number
 }
 
+interface PerformRequestOptions {
+  queryParameters?: any
+  bodyParameters?: any
+  additionalHeaders?: any
+  abortSignal?: any
+  responseType?: AxiosRequestConfig['responseType']
+}
+
 export default class ApiCall {
   private readonly apiKey: string
   private readonly nodes: Node[]
@@ -51,8 +59,12 @@ export default class ApiCall {
     this.currentNodeIndex = -1
   }
 
-  get<T extends any>(endpoint: string, queryParameters: any = {}, { abortSignal = null } = {}): Promise<T> {
-    return this.performRequest<T>('get', endpoint, { queryParameters, abortSignal })
+  get<T extends any>(
+    endpoint: string,
+    queryParameters: any = {},
+    { abortSignal, responseType }: { abortSignal?: any; responseType?: AxiosRequestConfig['responseType'] } = {}
+  ): Promise<T> {
+    return this.performRequest<T>('get', endpoint, { queryParameters, abortSignal, responseType })
   }
 
   delete<T extends any>(endpoint: string, queryParameters: any = {}): Promise<T> {
@@ -83,13 +95,9 @@ export default class ApiCall {
       queryParameters = null,
       bodyParameters = null,
       additionalHeaders = {},
-      abortSignal = null
-    }: {
-      queryParameters?: any
-      bodyParameters?: any
-      additionalHeaders?: any
-      abortSignal?: any
-    }
+      abortSignal = null,
+      responseType = null
+    }: PerformRequestOptions
   ): Promise<T> {
     this.configuration.validate()
 
@@ -118,6 +126,7 @@ export default class ApiCall {
           timeout: this.connectionTimeoutSeconds * 1000,
           maxContentLength: Infinity,
           maxBodyLength: Infinity,
+          responseType,
           validateStatus: (status) => {
             /* Override default validateStatus, which only considers 2xx a success.
                 In our case, if the server returns any HTTP code, we will handle it below.

--- a/src/Typesense/Documents.ts
+++ b/src/Typesense/Documents.ts
@@ -1,3 +1,4 @@
+import type { ReadStream } from 'fs'
 import ApiCall from './ApiCall'
 import Configuration from './Configuration'
 import { ImportError } from './Errors'
@@ -222,6 +223,13 @@ export default class Documents<T extends DocumentSchema = {}>
    * Returns a JSONL string for all the documents in this collection
    */
   async export(options: DocumentsExportParameters = {}): Promise<string> {
-    return await this.apiCall.get<string>(this.endpointPath('export'), options)
+    return this.apiCall.get<string>(this.endpointPath('export'), options)
+  }
+
+  /**
+   * Returns a NodeJS readable stream of JSONL for all the documents in this collection.
+   */
+  async exportStream(options: DocumentsExportParameters = {}): Promise<ReadStream> {
+    return this.apiCall.get<ReadStream>(this.endpointPath('export'), options, { responseType: 'stream' })
   }
 }

--- a/test/Typesense/Documents.spec.js
+++ b/test/Typesense/Documents.spec.js
@@ -1,3 +1,4 @@
+import fs from 'fs'
 import chai from 'chai'
 import chaiAsPromised from 'chai-as-promised'
 import { Client as TypesenseClient } from '../../src/Typesense'
@@ -499,6 +500,55 @@ describe('Documents', function () {
       expect(returnData)
         .to.eventually.deep.equal([JSON.stringify(document), JSON.stringify(anotherDocument)].join('\n'))
         .notify(done)
+    })
+  })
+
+  describe('.exportStream', () => {
+    const tempDirectory = 'test-files'
+    const tempFile = `${tempDirectory}/exportStreamData.jsonl`
+    const directoryExists = (dir) =>
+      fs.promises
+        .access(dir)
+        .then(() => true)
+        .catch(() => false)
+
+    beforeEach(async () => {
+      if (!(await directoryExists(tempDirectory))) {
+        await fs.promises.mkdir(tempDirectory)
+      }
+      await fs.promises.writeFile(tempFile, [JSON.stringify(document), JSON.stringify(anotherDocument)].join('\n'))
+    })
+
+    afterEach(async () => {
+      if (await directoryExists(tempDirectory)) {
+        await fs.promises.rm(tempDirectory, { recursive: true })
+      }
+    })
+
+    it('exports a nodejs stream', async () => {
+      mockAxios
+        .onGet(apiCall.uriFor('/collections/companies/documents/export', typesense.configuration.nodes[0]), undefined, {
+          Accept: 'application/json, text/plain, */*',
+          'Content-Type': 'application/json',
+          'X-TYPESENSE-API-KEY': typesense.configuration.apiKey
+        })
+        .reply((config) => {
+          expect(config.params.include_fields).to.equal('field1')
+          return [200, fs.createReadStream(tempFile)]
+        })
+
+      const stream = await documents.exportStream({ include_fields: 'field1' })
+      const getDataFromStream = () =>
+        new Promise((resolve, reject) => {
+          let finalData = ''
+          stream.on('data', (data) => {
+            finalData += data
+          })
+          stream.on('end', () => resolve(finalData))
+          stream.on('error', (err) => reject(err))
+        })
+      const data = await getDataFromStream()
+      expect(data).to.deep.equal([JSON.stringify(document), JSON.stringify(anotherDocument)].join('\n'))
     })
   })
 

--- a/test/Typesense/Documents.spec.js
+++ b/test/Typesense/Documents.spec.js
@@ -503,7 +503,7 @@ describe('Documents', function () {
     })
   })
 
-  describe('.exportStream', () => {
+  describe('.exportStream', function () {
     const tempDirectory = 'test-files'
     const tempFile = `${tempDirectory}/exportStreamData.jsonl`
     const directoryExists = (dir) =>
@@ -512,20 +512,20 @@ describe('Documents', function () {
         .then(() => true)
         .catch(() => false)
 
-    beforeEach(async () => {
+    beforeEach(async function () {
       if (!(await directoryExists(tempDirectory))) {
         await fs.promises.mkdir(tempDirectory)
       }
       await fs.promises.writeFile(tempFile, [JSON.stringify(document), JSON.stringify(anotherDocument)].join('\n'))
     })
 
-    afterEach(async () => {
+    afterEach(async function () {
       if (await directoryExists(tempDirectory)) {
         await fs.promises.rm(tempDirectory, { recursive: true })
       }
     })
 
-    it('exports a nodejs stream', async () => {
+    it('exports a nodejs stream', async function () {
       mockAxios
         .onGet(apiCall.uriFor('/collections/companies/documents/export', typesense.configuration.nodes[0]), undefined, {
           Accept: 'application/json, text/plain, */*',


### PR DESCRIPTION
## Change Summary
This pull request closes #87 

### Changes to `ApiCall.ts`

- `performRequest()` now accepts `responseType` as an optional parameter. That parameter is passed to Axios when making a request.
- `get()` now accepts `responseType` in it's optional parameters

### Changes to `Documents.ts`
- Added function called `exportStream`. It's functionally the same as `export()` the only difference is it now it passes `{ responseType: "stream" }` to the `this.apiCall.get()`.

### Additional Notes
[Axios doesn't support returning a stream in the browser](https://github.com/axios/axios/issues/479). So if this is called in the browser it'll just return a string like normal. Not sure if this needs to be documented or not. We could add a note to the JSDoc comment although I imagine most people wouldn't be using the export methods in the browser anyway since they require admin keys.

All tests are passing. I also did some basic tests in NodeJS and the Browser.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).