### PR TITLE
Adding Missing FieldType 'geopoint[]'

### DIFF
--- a/src/Typesense/Collection.ts
+++ b/src/Typesense/Collection.ts
@@ -15,6 +15,7 @@ export type FieldType =
   | 'float'
   | 'bool'
   | 'geopoint'
+  | 'geopoint[]'
   | 'string[]'
   | 'int32[]'
   | 'int64[]'


### PR DESCRIPTION
## Change Summary
Typesense v0.22.1 adds support for fields that are arrays of geopoints. However if you try to create a collection schema that includes a fields with the type `geopoint[]` you get a type error when using this library.

This PR adds the `geopoint[]` value to `FieldType` preventing devs from getting this inaccurate error.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
