### PR TITLE
Remove SearchOnlyDocuments circular dependency

### DIFF
--- a/src/Typesense/SearchOnlyDocuments.ts
+++ b/src/Typesense/SearchOnlyDocuments.ts
@@ -2,9 +2,9 @@ import RequestWithCache from './RequestWithCache'
 import ApiCall from './ApiCall'
 import Configuration from './Configuration'
 import Collections from './Collections'
-import Documents, { SearchableDocuments, SearchOptions, SearchParams, SearchResponse } from './Documents'
+import type { SearchableDocuments, SearchOptions, SearchParams, SearchResponse } from './Documents'
 
-const RESOURCEPATH = '/documents'
+const RESOURCEPATH = '/documents';
 
 export class SearchOnlyDocuments<T> implements SearchableDocuments<T> {
   protected requestWithCache: RequestWithCache = new RequestWithCache()
@@ -35,12 +35,12 @@ export class SearchOnlyDocuments<T> implements SearchableDocuments<T> {
   }
 
   protected endpointPath(operation?: string) {
-    return `${Collections.RESOURCEPATH}/${this.collectionName}${Documents.RESOURCEPATH}${
+    return `${Collections.RESOURCEPATH}/${this.collectionName}${RESOURCEPATH}${
       operation === undefined ? '' : '/' + operation
     }`
   }
 
   static get RESOURCEPATH() {
-    return RESOURCEPATH
+    return RESOURCEPATH;
   }
 }


### PR DESCRIPTION
## Change Summary

There seem to be an issue when building a production build, specifically using Vite.

`Documents.RESOURCEPATH` returns undefined. Since this is a getter defined in `SearchOnlyDocuments` and `Documents` gets it by *inheritance*, I figured we could probably just remove the reference to Documents. 

I think the issue is caused by the circular dependency between `SearchOnlyDocuments` and `Documents` and gets a bit muffled at build/shrinking time, so this looks like a proper fix.

I can confirmed it resolved our issue on our side.

See associated [Slack thread](https://typesense-community.slack.com/archives/C01P749MET0/p1641500212020400)

## PR Checklist

- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
