### PR TITLE
Fix: change HealthResponse to correct typing

### DIFF
--- a/src/Typesense/Health.ts
+++ b/src/Typesense/Health.ts
@@ -3,7 +3,7 @@ import ApiCall from './ApiCall'
 const RESOURCEPATH = '/health'
 
 export interface HealthResponse {
-  status: string
+  ok: boolean
 }
 
 export default class Health {


### PR DESCRIPTION
## Change Summary
Changed the type of HealthResponse to accurately reflect the actual response received from the /health endpoint.
See: https://typesense.org/docs/0.22.2/api/cluster-operations.html#health

This PR changes `status: string` to `ok: boolean` in the `HealthResponse` interface.

Fixes following typescript error:
![image](https://user-images.githubusercontent.com/12862194/154646966-718d88da-f05b-4b3b-a588-a26ee5edb24d.png)

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
