### PR TITLE
make SearchParams['query_by'] adhere to spec

### DIFF
--- a/lib/Typesense/Documents.d.ts
+++ b/lib/Typesense/Documents.d.ts
@@ -24,7 +24,7 @@ export interface DocumentSchema extends Record<string, any> {
 }
 export interface SearchParams {
     q: string;
-    query_by: string;
+    query_by: string | string[];
     query_by_weights?: string;
     prefix?: string | boolean;
     filter_by?: string;


### PR DESCRIPTION
[docs](https://typesense.org/docs/0.22.2/api/documents.html#search) allow string arrays for `SearchParams['query_by']`, provided typescript definitions don't.

I'm not signing shit, but this would fix #120.