### PR TITLE
Add typings for logger & logLevel options

### DIFF
--- a/src/Typesense/ApiCall.ts
+++ b/src/Typesense/ApiCall.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosRequestConfig, AxiosResponse, Method } from 'axios'
+import { Logger } from 'loglevel'
 import {
   HTTPError,
   ObjectAlreadyExists,
@@ -31,7 +32,7 @@ export default class ApiCall {
   private readonly numRetriesPerRequest: number
   private readonly additionalUserHeaders: Record<string, string>
 
-  private readonly logger: any
+  private readonly logger: Logger
   private currentNodeIndex: number
 
   constructor(private configuration: Configuration) {

--- a/src/Typesense/Configuration.ts
+++ b/src/Typesense/Configuration.ts
@@ -1,4 +1,5 @@
 import * as logger from 'loglevel'
+import { Logger, LogLevelDesc } from 'loglevel'
 import { MissingConfigurationError } from './Errors'
 
 export interface NodeConfiguration {
@@ -34,8 +35,8 @@ export interface ConfigurationOptions {
   cacheSearchResultsForSeconds?: number
   additionalHeaders?: Record<string, string>
 
-  logLevel?: logger.LogLevelDesc
-  logger?: any //todo
+  logLevel?: LogLevelDesc
+  logger?: Logger
 }
 
 export default class Configuration {
@@ -49,8 +50,8 @@ export default class Configuration {
   readonly sendApiKeyAsQueryParam: boolean
   readonly cacheSearchResultsForSeconds: number
   readonly useServerSideSearchCache: boolean
-  readonly logger: any
-  readonly logLevel: any
+  readonly logger: Logger
+  readonly logLevel: LogLevelDesc
   readonly additionalHeaders: Record<string, string>
 
   constructor(options: ConfigurationOptions) {


### PR DESCRIPTION
Fixes #125

## Change Summary
Adds typings for the `logLevel` and `logger` configuration options, delegating to the type defs from the `loglevel` dependency.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
