### PR TITLE
chore: add optional geo distance type on hits

### DIFF
--- a/lib/Typesense/Documents.d.ts
+++ b/lib/Typesense/Documents.d.ts
@@ -70,6 +70,9 @@ export interface SearchResponseHit<T extends DocumentSchema> {
             matched_tokens: string[];
         }
     ];
+    geo_distance_meters?: {
+		location?: number;
+    };
     document: T;
     text_match: number;
 }


### PR DESCRIPTION
## Change Summary
Adding missing `geo_distance_meters` type in Document Hit response

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).

### Questions.
Is `location` truly optional in this instance? Could we hit a case where a `geo_distance_meters` parameter is returned but location doesn't exist or has an undefined value?
