### PR TITLE
feat: add cache/clear to list of known operations

### DIFF
--- a/src/Typesense/Operations.ts
+++ b/src/Typesense/Operations.ts
@@ -5,7 +5,7 @@ const RESOURCEPATH = '/operations'
 export default class Operations {
   constructor(private apiCall: ApiCall) {}
 
-  async perform(operationName: 'vote' | 'snapshot' | string, queryParameters: Record<string, any> = {}): Promise<any> {
+  async perform(operationName: 'vote' | 'snapshot' | 'cache/clear' | string, queryParameters: Record<string, any> = {}): Promise<any> {
     return this.apiCall.post(`${RESOURCEPATH}/${operationName}`, {}, queryParameters)
   }
 }


### PR DESCRIPTION
Adds `cache/clear` option to the operation union type, to indicate it's existence.

This makes use of the existing operation endpoint here: https://github.com/typesense/typesense/blob/483ed4d533e8a657784472e3a3066298fa085c44/src/main/typesense_server.cpp#L77

It is, unfortunately, an undocumented flow. One that complements the usage of `useServerSideSearchCache` on the client side.

It would be really helpful to document that the use of the `useServerSideSearchCache`, or it's direct API dependant, `use_cache` ([link](https://typesense.org/docs/0.23.1/api/search.html#caching-parameters)), stores the result in memory, and can be cleared using the cache/clear operation when the immediate propagation of document update is needed.