### PR TITLE
MultiSearch: multiSearch.perform types

### DIFF
--- a/src/Typesense/MultiSearch.ts
+++ b/src/Typesense/MultiSearch.ts
@@ -19,11 +19,11 @@ export interface MultiSearchRequestsSchema {
   searches: (MultiSearchRequestSchema | MultiSearchRequestWithPresetSchema)[]
 }
 
-export interface MultiSearchResponse<T extends DocumentSchema = {}> {
-  results: SearchResponse<T>[]
+export interface MultiSearchResponse<T extends DocumentSchema[] = []> {
+  results: { [Index in keyof T]: SearchResponse<T[Index]> } & { length: T['length'] }
 }
 
-export default class MultiSearch<T extends DocumentSchema = {}> {
+export default class MultiSearch {
   private requestWithCache: RequestWithCache
 
   constructor(
@@ -38,7 +38,7 @@ export default class MultiSearch<T extends DocumentSchema = {}> {
     this.requestWithCache.clearCache()
   }
 
-  async perform(
+  async perform<T extends DocumentSchema[] = []>(
     searchRequests: MultiSearchRequestsSchema,
     commonParams: Partial<MultiSearchRequestSchema> = {},
     {


### PR DESCRIPTION
## Change Summary
- generic type is carried by perform function and not the class
- type annotation is a tuple of Document schema, and the return type is a mapped tuple of SearchResponse of the specified documentSchema, in the same order

Usage would be : 
```typescript
type Employee = {name: string}
type Company = {orgName: string}

res = await client.multiSearch.perform<[Employee, Company]>(
  [
    {q, query_by: "name", collection: "employees"},
    {q, query_by: "orgName", collection: "companies"}
  ]
)
[employees, companies] = res.results
# type of employees : Employee
# type of companies : Company
```
## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
