### PR TITLE
Typescript adjustments + search param array handling

### DIFF
--- a/src/Typesense/Collection.ts
+++ b/src/Typesense/Collection.ts
@@ -45,13 +45,14 @@ export interface CollectionSchema extends CollectionCreateSchema {
   num_memory_shards: number;
 }
 
-export interface CollectionUpdateFieldSchema extends CollectionFieldSchema {
-  drop?: boolean;
+export interface CollectionDropFieldSchema {
+  name: string;
+  drop: true;
 }
 
 export interface CollectionUpdateSchema
-  extends Partial<Omit<CollectionCreateSchema, "name">> {
-  fields?: CollectionUpdateFieldSchema[];
+  extends Partial<Omit<CollectionCreateSchema, "name" | "fields">> {
+  fields?: (CollectionFieldSchema | CollectionDropFieldSchema)[];
 }
 
 export default class Collection<T extends DocumentSchema = object> {

--- a/src/Typesense/Documents.ts
+++ b/src/Typesense/Documents.ts
@@ -33,39 +33,40 @@ export interface SearchParamsWithPreset extends Partial<SearchParams> {
   preset: string;
 }
 
+type OperationMode = "off" | "always" | "fallback";
 export interface SearchParams {
   // From https://typesense.org/docs/latest/api/documents.html#arguments
   q: string;
-  query_by: string;
-  query_by_weights?: string;
-  prefix?: string | boolean; // default: true
+  query_by: string | string[];
+  query_by_weights?: string | number[];
+  prefix?: string | boolean | boolean[]; // default: true
   filter_by?: string;
-  sort_by?: string; // default: text match desc
-  facet_by?: string;
+  sort_by?: string | string[]; // default: text match desc
+  facet_by?: string | string[];
   max_facet_values?: number;
   facet_query?: string;
   facet_query_num_typos?: number;
   page?: number; // default: 1
   per_page?: number; // default: 10, max 250
-  group_by?: string;
+  group_by?: string | string[];
   group_limit?: number; // default:
-  include_fields?: string;
-  exclude_fields?: string;
-  highlight_fields?: string; // default: all queried fields
-  highlight_full_fields?: string; // default: all fields
+  include_fields?: string | string[];
+  exclude_fields?: string | string[];
+  highlight_fields?: string | string[]; // default: all queried fields
+  highlight_full_fields?: string | string[]; // default: all fields
   highlight_affix_num_tokens?: number; // default: 4
   highlight_start_tag?: string; // default: <mark>
   highlight_end_tag?: string; // default: </mark>
   snippet_threshold?: number; // default: 30
-  num_typos?: string | number; // default: 2
+  num_typos?: string | number | number[]; // default: 2
   min_len_1typo?: number;
   min_len_2typo?: number;
-  split_join_tokens?: string;
+  split_join_tokens?: OperationMode;
   exhaustive_search?: boolean;
   drop_tokens_threshold?: number; // default: 10
   typo_tokens_threshold?: number; // default: 100
-  pinned_hits?: string;
-  hidden_hits?: string;
+  pinned_hits?: string | string[];
+  hidden_hits?: string | string[];
   limit_hits?: number; // default: no limit
   pre_segmented_query?: boolean;
   enable_overrides?: boolean;
@@ -74,9 +75,9 @@ export interface SearchParams {
   search_cutoff_ms?: number;
   use_cache?: boolean;
   max_candidates?: number;
-  infix?: string;
+  infix?: OperationMode | OperationMode[];
   preset?: string;
-  text_match_type?: string;
+  text_match_type?: "max_score" | "max_weight";
   vector_query?: string;
   "x-typesense-api-key"?: string;
   "x-typesense-user-id"?: string;

--- a/src/Typesense/Documents.ts
+++ b/src/Typesense/Documents.ts
@@ -95,6 +95,7 @@ export type SearchResponseHighlight<T> = T extends string | number
     };
 
 export interface SearchResponseHit<T extends DocumentSchema> {
+  curated?: true;
   highlights?: [
     {
       field: keyof T;

--- a/src/Typesense/SearchOnlyDocuments.ts
+++ b/src/Typesense/SearchOnlyDocuments.ts
@@ -40,6 +40,11 @@ export class SearchOnlyDocuments<T extends DocumentSchema>
     if (this.configuration.useServerSideSearchCache === true) {
       additionalQueryParams["use_cache"] = true;
     }
+    for (const key in searchParameters) {
+      if (Array.isArray(searchParameters[key])) {
+        additionalQueryParams[key] = searchParameters[key].join(",");
+      }
+    }
     const queryParams = Object.assign(
       {},
       searchParameters,


### PR DESCRIPTION
## Change Summary
1. [Add `curated` param to `SearchResponseHit` type](https://github.com/typesense/typesense-js/commit/32377152dfa98b20c7fa091dd009c7ce3d2566c4)
2. [Improve `drop` field schema for `collection.update()`](https://github.com/typesense/typesense-js/commit/45b73de111bcc20f039e0fdd3133def56c9d2ccc)
  - Prior implementation required "type" to be specified when dropping a field. Now only name, and `drop: true` are required/valid.
3. [Improved handling of searchParams](https://github.com/typesense/typesense-js/commit/4150173099685193522c5aa380c7c238d3c8da98)
  - When specifying search params that are potentially comma separated, an array can now be passed which automatically joins the values with a comma into one string to then pass along to the search endpoint.
  - See commit for more detail.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
