### PR TITLE
Use ImportResponse[] as type of ImportError.importResults

### DIFF
--- a/src/Typesense/Errors/ImportError.ts
+++ b/src/Typesense/Errors/ImportError.ts
@@ -1,8 +1,8 @@
 import TypesenseError from "./TypesenseError";
-import { ImportResponseFail } from "../Documents";
+import { ImportResponse } from "../Documents";
 
 export default class ImportError extends TypesenseError {
-  importResults: ImportResponseFail;
+  importResults: ImportResponse[];
   constructor(message, importResults) {
     super(message);
     this.importResults = importResults;

--- a/src/Typesense/Errors/ImportError.ts
+++ b/src/Typesense/Errors/ImportError.ts
@@ -3,7 +3,7 @@ import { ImportResponse } from "../Documents";
 
 export default class ImportError extends TypesenseError {
   importResults: ImportResponse[];
-  constructor(message, importResults) {
+  constructor(message: string, importResults: ImportResponse[]) {
     super(message);
     this.importResults = importResults;
   }


### PR DESCRIPTION
## Change Summary
The docs indicate that the error thrown by `import()` (as in: `client.collections(...).documents().import(...)`) contains a key `importResults`. In my usage, I found that the runtime type of the value of `importResults` is an array, which seems to contain either `ImportResponseSuccess` or `ImportResponseFail`. At the moment I'm force-casting to override the type given by the library, but if my experimentation is correct, it'd be good to include the correct type here.

## PR Checklist
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
