### PR TITLE
refactor: improve typing as required by tsc 5.3 or higher

### DIFF
--- a/src/Typesense/Aliases.ts
+++ b/src/Typesense/Aliases.ts
@@ -31,7 +31,7 @@ export default class Aliases {
     return this.apiCall.get<CollectionAliasesResponseSchema>(RESOURCEPATH);
   }
 
-  private endpointPath(aliasName): string {
+  private endpointPath(aliasName: string): string {
     return `${Aliases.RESOURCEPATH}/${aliasName}`;
   }
 

--- a/src/Typesense/ApiCall.ts
+++ b/src/Typesense/ApiCall.ts
@@ -19,6 +19,7 @@ const UNHEALTHY = false;
 interface Node extends NodeConfiguration {
   isHealthy: boolean;
   index: string | number;
+  lastAccessTimestamp: number;
 }
 
 export default class ApiCall {
@@ -340,7 +341,7 @@ export default class ApiCall {
     return candidateNode;
   }
 
-  nodeDueForHealthcheck(node, requestNumber = 0): boolean {
+  nodeDueForHealthcheck(node: Node, requestNumber = 0): boolean {
     const isDueForHealthcheck =
       Date.now() - node.lastAccessTimestamp >
       this.healthcheckIntervalSeconds * 1000;
@@ -364,12 +365,12 @@ export default class ApiCall {
     });
   }
 
-  setNodeHealthcheck(node, isHealthy): void {
+  setNodeHealthcheck(node: Node, isHealthy: boolean): void {
     node.isHealthy = isHealthy;
     node.lastAccessTimestamp = Date.now();
   }
 
-  uriFor(endpoint: string, node): string {
+  uriFor(endpoint: string, node: NodeConfiguration): string {
     if (node.url != null) {
       return `${node.url}${endpoint}`;
     }
@@ -377,7 +378,7 @@ export default class ApiCall {
   }
 
   defaultHeaders(): any {
-    const defaultHeaders = {};
+    const defaultHeaders: Record<string, string> = {};
     if (!this.sendApiKeyAsQueryParam) {
       defaultHeaders[APIKEYHEADERNAME] = this.apiKey;
     }
@@ -385,7 +386,7 @@ export default class ApiCall {
     return defaultHeaders;
   }
 
-  async timer(seconds): Promise<void> {
+  async timer(seconds: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, seconds * 1000));
   }
 

--- a/src/Typesense/Documents.ts
+++ b/src/Typesense/Documents.ts
@@ -248,7 +248,8 @@ export default class Documents<T extends DocumentSchema = object>
   ): Promise<UpdateByFilterResponse | T> {
     if (!document) throw new Error("No document provided");
 
-    if (options["filter_by"] != null) {
+    // @ts-expect-error filter_by does not exist in options
+    if (options ["filter_by"] != null) {
       return this.apiCall.patch<T>(
         this.endpointPath(),
         document,

--- a/src/Typesense/Errors/ImportError.ts
+++ b/src/Typesense/Errors/ImportError.ts
@@ -1,9 +1,9 @@
 import TypesenseError from "./TypesenseError";
-import { ImportResponseFail } from "../Documents";
+import { ImportResponseFail, ImportResponse } from "../Documents";
 
 export default class ImportError extends TypesenseError {
-  importResults: ImportResponseFail;
-  constructor(message, importResults) {
+  importResults: ImportResponseFail | ImportResponse[];
+  constructor(message: string, importResults: ImportResponseFail | ImportResponse[]) {
     super(message);
     this.importResults = importResults;
   }

--- a/src/Typesense/MultiSearch.ts
+++ b/src/Typesense/MultiSearch.ts
@@ -54,12 +54,12 @@ export default class MultiSearch {
         .cacheSearchResultsForSeconds,
     }: { cacheSearchResultsForSeconds?: number } = {}
   ): Promise<MultiSearchResponse<T>> {
-    const additionalHeaders = {};
+    const additionalHeaders: Record<string, string> = {};
     if (this.useTextContentType) {
       additionalHeaders["content-type"] = "text/plain";
     }
 
-    const additionalQueryParams = {};
+    const additionalQueryParams: Record<string, boolean> = {};
     if (this.configuration.useServerSideSearchCache === true) {
       additionalQueryParams["use_cache"] = true;
     }

--- a/src/Typesense/SearchOnlyDocuments.ts
+++ b/src/Typesense/SearchOnlyDocuments.ts
@@ -36,12 +36,14 @@ export class SearchOnlyDocuments<T extends DocumentSchema>
       abortSignal = null,
     }: SearchOptions = {}
   ): Promise<SearchResponse<T>> {
-    const additionalQueryParams = {};
+    const additionalQueryParams: Record<string, boolean> = {};
     if (this.configuration.useServerSideSearchCache === true) {
       additionalQueryParams["use_cache"] = true;
     }
     for (const key in searchParameters) {
+      // @ts-expect-error allow random lookup
       if (Array.isArray(searchParameters[key])) {
+	// @ts-expect-error allow random lookup
         additionalQueryParams[key] = searchParameters[key].join(",");
       }
     }


### PR DESCRIPTION
## Change Summary
The current library generates about 20 errors when included in a typescript project, possibly only when using TypeScript 5.3 or higher, see #183.

This is my first PR, a bit unclear about the process. For example "npm run format" formats a whole bunch of things, not related to my PR. So just stuck to what I guessed to be the code style in this library.

"npm build" generates errors about unused suppressions, not sure what the fix should be there. The suppressions are clearly needed, but the code could be improved to be more typesafe.

I'm also unsure if ImportError works correctly, it gets passed in two very different types, and it looks to me the array version is an error, but this is what the current code does.

## PR Checklist
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
