### PR TITLE
[Cloudflare] Fix the 'credentials' field on 'RequestInitializerDict' is not implemented

### DIFF
--- a/src/Typesense/ApiCall.ts
+++ b/src/Typesense/ApiCall.ts
@@ -205,6 +205,14 @@ export default class ApiCall {
           ],
         };
 
+        // credential field is set by default (https://github.com/axios/axios/pull/6505)
+        // which is causing issue when running cloudflare worker (// https://github.com/cloudflare/workers-sdk/issues/2514)
+        // We explicitly set "credentials" as undefined if it's not supported
+        const isCredentialsSupported = "credentials" in Request.prototype; 
+        if (!isCredentialsSupported) {
+          requestOptions.credentials = undefined;
+        }
+
         if (skipConnectionTimeout !== true) {
           requestOptions.timeout = this.connectionTimeoutSeconds * 1000;
         }

--- a/src/Typesense/ApiCall.ts
+++ b/src/Typesense/ApiCall.ts
@@ -206,11 +206,11 @@ export default class ApiCall {
         };
 
         // credential field is set by default (https://github.com/axios/axios/pull/6505)
-        // which is causing issue when running cloudflare worker (// https://github.com/cloudflare/workers-sdk/issues/2514)
+        // which is causing issue when running cloudflare worker (https://github.com/cloudflare/workers-sdk/issues/2514)
         // We explicitly set "credentials" as undefined if it's not supported
         const isCredentialsSupported = "credentials" in Request.prototype; 
         if (!isCredentialsSupported) {
-          requestOptions.credentials = undefined;
+          requestOptions.withCredentials = undefined;
         }
 
         if (skipConnectionTimeout !== true) {


### PR DESCRIPTION
## Change Summary
credential field is [set by default](https://github.com/axios/axios/pull/6505), which is causing issue when [running with cloudflare worker](https://github.com/cloudflare/workers-sdk/issues/2514)

We explicitly set "credentials" as undefined if it's not supported

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
