### PR TITLE
feat(search_params): add drop_tokens_mode to search params interface

### DIFF
--- a/src/Typesense/Documents.ts
+++ b/src/Typesense/Documents.ts
@@ -34,6 +34,11 @@ export interface SearchParamsWithPreset extends Partial<SearchParams> {
   preset: string;
 }
 
+type DropTokensMode =
+  | "right_to_left"
+  | "left_to_right"
+  | "both_sides:3";
+
 type OperationMode = "off" | "always" | "fallback";
 export interface SearchParams {
   // From https://typesense.org/docs/latest/api/documents.html#arguments
@@ -71,6 +76,7 @@ export interface SearchParams {
   split_join_tokens?: OperationMode;
   exhaustive_search?: boolean;
   drop_tokens_threshold?: number; // default: 10
+  drop_tokens_mode?: DropTokensMode;
   typo_tokens_threshold?: number; // default: 100
   pinned_hits?: string | string[];
   hidden_hits?: string | string[];


### PR DESCRIPTION
## Change Summary
- Introduce the `drop_tokens_mode` parameter to the `SearchParams` interface, allowing more fine-grained control over token dropping behavior during search operations.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
