### PR TITLE
fix: add override tags params to search params interface

### DIFF
--- a/src/Typesense/Documents.ts
+++ b/src/Typesense/Documents.ts
@@ -83,6 +83,7 @@ export interface SearchParams {
   limit_hits?: number; // default: no limit
   pre_segmented_query?: boolean;
   enable_overrides?: boolean;
+  override_tags?: string | string[];
   prioritize_exact_match?: boolean; // default: true
   prioritize_token_position?: boolean;
   prioritize_num_matching_fields?: boolean;


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
- Enhance the `SearchParams` interface in `Documents.ts` by adding the `override_tags` option. This option allows specifying tags for overriding search behavior, providing greater flexibility in query customization.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
