### PR TITLE
fix: allow numRetries = 0

### DIFF
--- a/src/Typesense/ApiCall.ts
+++ b/src/Typesense/ApiCall.ts
@@ -313,9 +313,11 @@ export default class ApiCall {
           }"`,
         );
         // this.logger.debug(error.stack)
-        this.logger.warn(
-          `Request #${requestNumber}: Sleeping for ${this.retryIntervalSeconds}s and then retrying request...`,
-        );
+        if (numTries < this.numRetriesPerRequest + 1) {
+          this.logger.warn(
+            `Request #${requestNumber}: Sleeping for ${this.retryIntervalSeconds}s and then retrying request...`,
+          );
+        }
         await this.timer(this.retryIntervalSeconds);
       } finally {
         if (abortSignal && abortListener) {

--- a/src/Typesense/Configuration.ts
+++ b/src/Typesense/Configuration.ts
@@ -144,9 +144,9 @@ export default class Configuration {
       options.connectionTimeoutSeconds || options.timeoutSeconds || 5;
     this.healthcheckIntervalSeconds = options.healthcheckIntervalSeconds || 60;
     this.numRetries =
-      options.numRetries ||
-      this.nodes.length + (this.nearestNode == null ? 0 : 1) ||
-      3;
+      (options.numRetries !== undefined && options.numRetries >= 0
+        ? options.numRetries
+        : this.nodes.length + (this.nearestNode == null ? 0 : 1)) || 3;
     this.retryIntervalSeconds = options.retryIntervalSeconds || 0.1;
 
     this.apiKey = options.apiKey;


### PR DESCRIPTION
## Change Summary
Fixed the way numRetries is set during configuration.
WAS: if `falsy` then use fallback (i.e. use node config, or eventually default value of 3)
NOW: use fallback only if undefined

## PR Checklist
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
