### PR TITLE
fix: add autodelete parameter to api key create schema

### DIFF
--- a/src/Typesense/Key.ts
+++ b/src/Typesense/Key.ts
@@ -8,6 +8,7 @@ export interface KeyCreateSchema {
   value?: string;
   value_prefix?: string;
   expires_at?: number;
+  autodelete?: boolean;
 }
 
 export interface KeyDeleteSchema {
@@ -19,7 +20,10 @@ export interface KeySchema extends KeyCreateSchema {
 }
 
 export default class Key {
-  constructor(private id: number, private apiCall: ApiCall) {}
+  constructor(
+    private id: number,
+    private apiCall: ApiCall,
+  ) {}
 
   async retrieve(): Promise<KeySchema> {
     return this.apiCall.get<KeySchema>(this.endpointPath());


### PR DESCRIPTION
## Change Summary
Add the `autodelete` parameter from the [API key](https://typesense.org/docs/27.1/api/api-keys.html#arguments) arguments to the API key interface.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
