### PR TITLE
Add enable_analytics to types

### DIFF
--- a/lib/Typesense/Documents.d.ts
+++ b/lib/Typesense/Documents.d.ts
@@ -68,6 +68,7 @@ export interface SearchParams {
     hidden_hits?: string | string[];
     limit_hits?: number;
     pre_segmented_query?: boolean;
+    enable_analytics?: boolean;
     enable_overrides?: boolean;
     override_tags?: string | string[];
     prioritize_exact_match?: boolean;

--- a/src/Typesense/Documents.ts
+++ b/src/Typesense/Documents.ts
@@ -82,6 +82,7 @@ export interface SearchParams {
   hidden_hits?: string | string[];
   limit_hits?: number; // default: no limit
   pre_segmented_query?: boolean;
+  enable_analytics?: boolean;
   enable_overrides?: boolean;
   override_tags?: string | string[];
   prioritize_exact_match?: boolean; // default: true


### PR DESCRIPTION
## Change Summary
Added enable_analytics to Document type. Fixes https://github.com/typesense/typesense-js/issues/235

## PR Checklist
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
