### PR TITLE
fix(analytics): improve event type definition and enforce required data property

### DIFF
--- a/src/Typesense/AnalyticsEvent.ts
+++ b/src/Typesense/AnalyticsEvent.ts
@@ -1,5 +1,5 @@
 export interface AnalyticsEventCreateSchema {
   type: string;
   name: string;
-  data?: object;
+  data?: Record<string, unknown>;
 }

--- a/src/Typesense/AnalyticsEvent.ts
+++ b/src/Typesense/AnalyticsEvent.ts
@@ -1,5 +1,5 @@
 export interface AnalyticsEventCreateSchema {
   type: string;
   name: string;
-  data?: Record<string, unknown>;
+  data: Record<string, unknown>;
 }


### PR DESCRIPTION
## Change Summary
## Rationale
The current implementation of the Analytics Event interface has two issues that could lead to runtime errors and type inconsistencies:

1. The `data` property is marked as optional (`?`), but according to Typesense's OpenAPI specification, it should be required.
2. The use of the `object` type for the `data` property is too permissive and doesn't provide proper type safety or property access guarantees.

These changes align our type definitions with the official Typesense API specification while providing better type safety and developer experience.

## Changes

### Code Changes
1. **In `src/Typesense/AnalyticsEvent.ts`**:
   - Made `data` property required by removing the optional (`?`) modifier
   - Changed `data` type from `object` to `Record<string, unknown>` to:
     - Ensure only plain objects with string keys are accepted
     - Allow proper property access
     - Prevent assignment of null or non-object values
     - Use `unknown` instead of `any` for better type safety

Before:
```typescript
export interface AnalyticsEventCreateSchema {
  type: string;
  name: string;
  data?: object;
}

// These would compile but could cause runtime issues:
const event1: AnalyticsEventCreateSchema = {
  type: "search",
  name: "product_search",
  data: null // ✅ Compiles but shouldn't
};

const event2: AnalyticsEventCreateSchema = {
  type: "click",
  name: "product_click",
  data: new Date() // ✅ Compiles but shouldn't
};

const event3: AnalyticsEventCreateSchema = {
  type: "view",
  name: "product_view",
  data: { productId: "123" }
};
event3.data.productId; // ❌ Error: Property 'productId' does not exist on type 'object'
```

After:
```typescript
export interface AnalyticsEventCreateSchema {
  type: string;
  name: string;
  data: Record<string, unknown>;
}

// Better type safety and developer experience:
const event1: AnalyticsEventCreateSchema = {
  type: "search",
  name: "product_search",
  data: null // ❌ Type error: Type 'null' is not assignable to type 'Record<string, unknown>'
};

const event2: AnalyticsEventCreateSchema = {
  type: "click",
  name: "product_click",
  data: new Date() // ❌ Type error: Type 'Date' is not assignable to type 'Record<string, unknown>'
};

const event3: AnalyticsEventCreateSchema = {
  type: "view",
  name: "product_view",
  data: {
    productId: "123",
    timestamp: Date.now(),
    metadata: {
      category: "electronics",
      price: 299.99
    }
  }
};
event3.data.productId; // ✅ Property access works
```

### Context
This change is driven by the [Typesense OpenAPI](https://raw.githubusercontent.com/typesense/typesense-api-spec/master/openapi.yml) specification which clearly defines that the `data` property is required in the `AnalyticsEventCreateSchema`:

```yaml
AnalyticsEventCreateSchema:
  type: object
  required:
    - type
    - name
    - data
```

The use of `Record<string, unknown>` instead of `object` provides better type safety and developer experience by:
1. Preventing null assignments
2. Allowing property access
3. Ensuring only plain objects with string keys are accepted
4. Using `unknown` for better type safety compared to `any`

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
