### PR TITLE
add missing facet_strategy option to SearchParams to catch up to v27

### DIFF
--- a/lib/Typesense/Documents.d.ts
+++ b/lib/Typesense/Documents.d.ts
@@ -45,6 +45,7 @@ export interface SearchParams {
     facet_query?: string;
     facet_query_num_typos?: number;
     facet_return_parent?: string;
+    facet_strategy?: 'exhaustive' | 'top_values' | 'automatic';
     page?: number;
     per_page?: number;
     group_by?: string | string[];


### PR DESCRIPTION
## Change Summary
TypeScript was complaining about invalid config values when I was fooling around with the new "facet_strategy" parameter that was introduced in v27.0. It seems like this was the only missing parameter for faceting, phew! :)

## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
