### PR TITLE
Request cache: Fix type error when deleting possibly undefined oldest entry

### DIFF
--- a/src/Typesense/RequestWithCache.ts
+++ b/src/Typesense/RequestWithCache.ts
@@ -83,13 +83,17 @@ export default class RequestWithCache {
     const isCacheOverMaxSize = this.responseCache.size > maxSize;
     if (isCacheOverMaxSize) {
       const oldestEntry = this.responseCache.keys().next().value;
-      this.responseCache.delete(oldestEntry);
+      if (oldestEntry) {
+        this.responseCache.delete(oldestEntry);
+      }
     }
     const isResponsePromiseCacheOverMaxSize =
       this.responsePromiseCache.size > maxSize;
     if (isResponsePromiseCacheOverMaxSize) {
       const oldestEntry = this.responsePromiseCache.keys().next().value;
-      this.responsePromiseCache.delete(oldestEntry);
+      if (oldestEntry) {
+        this.responsePromiseCache.delete(oldestEntry);
+      }
     }
     return response as T;
   }


### PR DESCRIPTION
## Change Summary
Fixes a tsc error about `oldestEntry` potentially being undefined:
```ts
    const isCacheOverMaxSize = this.responseCache.size > maxSize;
    if (isCacheOverMaxSize) {
      const oldestEntry = this.responseCache.keys().next().value; // ❌ Argument of type 'string | undefined' is not assignable to parameter of type 'string'.

      this.responseCache.delete(oldestEntry);
    }
```
to just checking if it is defined, otherwise it just moves on:
```ts
      const oldestEntry = this.responseCache.keys().next().value;
      if (oldestEntry) {
        this.responseCache.delete(oldestEntry);
      }
```
This change tries to address the type error while not introducing any regressions by changing the underlying logic by throwing or returning early.
## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
