### PR TITLE
Add facet strategy to search params interface

### DIFF
--- a/src/Typesense/Documents.ts
+++ b/src/Typesense/Documents.ts
@@ -107,6 +107,7 @@ export interface SearchParams {
   facet_query?: string;
   facet_query_num_typos?: number;
   facet_return_parent?: string;
+  facet_strategy?: "exhaustive" | "top_values" | "automatic";
   page?: number; // default: 1
   per_page?: number; // default: 10, max 250
   group_by?: string | string[];


### PR DESCRIPTION
## Change Summary
Some changes must have removed `facet_strategy` from the `SearchParams` interface, as reported by #244. This adds `facet_strategy` back to the `SaerchParams` interface.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
