### PR TITLE
fix(hit-res): use template literals to assert type of stringified nums

### DIFF
--- a/src/Typesense/Documents.ts
+++ b/src/Typesense/Documents.ts
@@ -182,10 +182,10 @@ export interface SearchResponseHit<T extends DocumentSchema> {
   document: T;
   text_match: number;
   text_match_info?: {
-    best_field_score: string; // To prevent scores from being truncated by JSON spec
+    best_field_score: `${number}`; // To prevent scores from being truncated by JSON spec
     best_field_weight: number;
     fields_matched: number;
-    score: string; // To prevent scores from being truncated by JSON spec
+    score: `${number}`; // To prevent scores from being truncated by JSON spec
     tokens_matched: number;
   };
 }


### PR DESCRIPTION
## Change Summary
Since `text_match_info` returns `best_field_score` and `score` as numbers in string format, Typescript's template literals allow to assert that the underlying type is a number. This change provides enhancements to the overall typesafety of the client.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
