### PR TITLE
fix: handle undefined error codes in logger warnings

### DIFF
--- a/src/Typesense/ApiCall.ts
+++ b/src/Typesense/ApiCall.ts
@@ -306,7 +306,7 @@ export default class ApiCall {
         this.logger.warn(
           `Request #${requestNumber}: Request to Node ${
             node.index
-          } failed due to "${error.code} ${error.message}${
+          } failed due to "${error?.code ?? ""} ${error.message}${
             error.response == null
               ? ""
               : " - " + JSON.stringify(error.response?.data)


### PR DESCRIPTION
## Change Summary
This handles cases where the error code isn't returned by the error like here:
```shell
Request #1734010721681: Request to Node 0 failed due to "undefined Request failed with HTTP code 503"
```

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
