### PR TITLE
ci: bump actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
       - run: npm run build
       - run: npm run ci-lint
       - run: npm run ci-test
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: coverage
           path: coverage/


### PR DESCRIPTION
## Change Summary
Since  `actions/upload-artifact@v3` is getting deprecated, new workflow runs will be failing after Jan 30. This just bumps the version to the latest supported one.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
