### PR TITLE
fix(documents): throw on empty lists of documents

### DIFF
--- a/src/Typesense/Documents.ts
+++ b/src/Typesense/Documents.ts
@@ -1,7 +1,7 @@
 import type { ReadStream } from "fs";
 import ApiCall from "./ApiCall";
 import Configuration from "./Configuration";
-import { ImportError } from "./Errors";
+import { ImportError, RequestMalformed } from "./Errors";
 import { SearchOnlyDocuments } from "./SearchOnlyDocuments";
 
 // Todo: use generic to extract filter_by values
@@ -388,6 +388,9 @@ export default class Documents<T extends DocumentSchema = object>
   ): Promise<string | ImportResponse[]> {
     let documentsInJSONLFormat;
     if (Array.isArray(documents)) {
+      if (documents.length === 0) {
+        throw new RequestMalformed("No documents provided");
+      }
       try {
         documentsInJSONLFormat = documents
           .map((document) => JSON.stringify(document))
@@ -410,6 +413,9 @@ export default class Documents<T extends DocumentSchema = object>
       }
     } else {
       documentsInJSONLFormat = documents;
+      if (isEmptyString(documentsInJSONLFormat)) {
+        throw new RequestMalformed("No documents provided");
+      }
     }
 
     const resultsInJSONLFormat = await this.apiCall.performRequest<string>(
@@ -513,4 +519,8 @@ export default class Documents<T extends DocumentSchema = object>
       responseType: "stream",
     });
   }
+}
+
+function isEmptyString(str: string | null | undefined): boolean {
+  return str == null || str === "" || str.length === 0;
 }

--- a/test/Typesense/Documents.spec.js
+++ b/test/Typesense/Documents.spec.js
@@ -436,6 +436,65 @@ describe("Documents", function () {
   });
 
   describe(".import", function () {
+    context("when an empty array of documents is passed", function () {
+      it("throws RequestMalformed error", function (done) {
+        documents
+          .import([])
+          .then(() => {
+            done(new Error("Expected import to throw RequestMalformed error"));
+          })
+          .catch((error) => {
+            expect(error.constructor.name).to.eq("RequestMalformed");
+            expect(error.message).to.eq("No documents provided");
+            done();
+          });
+      });
+    });
+
+    context("when an empty string is passed", function () {
+      it("throws RequestMalformed error", function (done) {
+        documents
+          .import("")
+          .then(() => {
+            done(new Error("Expected import to throw RequestMalformed error"));
+          })
+          .catch((error) => {
+            expect(error.constructor.name).to.eq("RequestMalformed");
+            expect(error.message).to.eq("No documents provided");
+            done();
+          });
+      });
+    });
+
+    context("when null is passed as JSONL string", function () {
+      it("throws RequestMalformed error", function (done) {
+        documents
+          .import(null)
+          .then(() => {
+            done(new Error("Expected import to throw RequestMalformed error"));
+          })
+          .catch((error) => {
+            expect(error.constructor.name).to.eq("RequestMalformed");
+            expect(error.message).to.eq("No documents provided");
+            done();
+          });
+      });
+    });
+
+    context("when undefined is passed as JSONL string", function () {
+      it("throws RequestMalformed error", function (done) {
+        documents
+          .import(undefined)
+          .then(() => {
+            done(new Error("Expected import to throw RequestMalformed error"));
+          })
+          .catch((error) => {
+            expect(error.constructor.name).to.eq("RequestMalformed");
+            expect(error.message).to.eq("No documents provided");
+            done();
+          });
+      });
+    });
     context("when a query paramater is passed", function () {
       it("passes the query parameter to the API", function (done) {
         mockAxios


### PR DESCRIPTION
### TDLR
Addresses #188 

## Change Summary

This pull request introduces a new error handling mechanism in the `Documents` class within the `src/Typesense/Documents.ts` file. The main changes include the addition of a new error type and checks to ensure that provided documents are not empty.

Error handling improvements:

* [`src/Typesense/Documents.ts`](diffhunk://#diff-1e0565f0f17e3dfb64595df01f7506e4c30037e834ac03d758198f25e05c397eL4-R4): Added a new error type `RequestMalformed` to the import statement from `./Errors`.
* [`src/Typesense/Documents.ts`](diffhunk://#diff-1e0565f0f17e3dfb64595df01f7506e4c30037e834ac03d758198f25e05c397eR391-R393): Added a check to throw a `RequestMalformed` error if the provided documents array is empty.
* [`src/Typesense/Documents.ts`](diffhunk://#diff-1e0565f0f17e3dfb64595df01f7506e4c30037e834ac03d758198f25e05c397eR416-R418): Added a check to throw a `RequestMalformed` error if the provided documents string is empty.

Utility function addition:

* [`src/Typesense/Documents.ts`](diffhunk://#diff-1e0565f0f17e3dfb64595df01f7506e4c30037e834ac03d758198f25e05c397eR523-R526): Added a new utility function `isEmptyString` to check if a string is null, undefined, or empty.
<!--- Described your changes here -->

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
