### PR TITLE
fix(collection): make `token_separators` & `symbols_to_index` partial

### DIFF
--- a/src/Typesense/Collection.ts
+++ b/src/Typesense/Collection.ts
@@ -29,9 +29,8 @@ export type FieldType =
   | "image";
 
 export interface CollectionFieldSchema
-  extends Pick<
-    CollectionCreateSchema,
-    "token_separators" | "symbols_to_index"
+  extends Partial<
+    Pick<CollectionCreateSchema, "token_separators" | "symbols_to_index">
   > {
   name: string;
   type: FieldType;


### PR DESCRIPTION
## Change Summary
The [`Pick<T,K>`](https://www.typescriptlang.org/docs/handbook/utility-types.html#picktype-keys) type doesn't infer if the keys are optional or not, leading to `token_separators` and `symbols_to_index` being required in the `Field` type.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
