### PR TITLE
Make `fields` property conditional based on `src_name` in collection creation

### DIFF
--- a/src/Typesense/Collections.ts
+++ b/src/Typesense/Collections.ts
@@ -1,10 +1,9 @@
 import ApiCall from "./ApiCall";
-import { CollectionFieldSchema, CollectionSchema } from "./Collection";
+import type { CollectionFieldSchema, CollectionSchema } from "./Collection";
 
-export interface CollectionCreateSchema {
+interface BaseCollectionCreateSchema {
   name: string;
   default_sorting_field?: string;
-  fields?: CollectionFieldSchema[];
   symbols_to_index?: string[];
   token_separators?: string[];
   enable_nested_fields?: boolean;
@@ -13,6 +12,26 @@ export interface CollectionCreateSchema {
     model_name?: string;
   };
 }
+
+interface CollectionCreateSchemaWithSrc extends BaseCollectionCreateSchema {
+  fields?: CollectionFieldSchema[];
+}
+
+interface CollectionCreateSchemaWithoutSrc extends BaseCollectionCreateSchema {
+  fields: CollectionFieldSchema[];
+}
+
+/**
+ * Defines the schema for creating a collection in Typesense.
+ *
+ * If the `src_name` property in `Options` is a string, the `fields` prop is optional, and only used for embedding fields.
+ * Otherwise, `fields` will be required.
+ */
+export type CollectionCreateSchema<
+  Options extends CollectionCreateOptions = CollectionCreateOptions,
+> = Options["src_name"] extends string
+  ? CollectionCreateSchemaWithSrc
+  : CollectionCreateSchemaWithoutSrc;
 
 export interface CollectionCreateOptions {
   src_name?: string;
@@ -27,9 +46,9 @@ const RESOURCEPATH = "/collections";
 export default class Collections {
   constructor(private apiCall: ApiCall) {}
 
-  async create(
-    schema: CollectionCreateSchema,
-    options: CollectionCreateOptions = {},
+  async create<const Options extends CollectionCreateOptions>(
+    schema: CollectionCreateSchema<Options>,
+    options?: Options,
   ): Promise<CollectionSchema> {
     return this.apiCall.post<CollectionSchema>(RESOURCEPATH, schema, options);
   }

--- a/src/Typesense/Collections.ts
+++ b/src/Typesense/Collections.ts
@@ -13,7 +13,8 @@ interface BaseCollectionCreateSchema {
   };
 }
 
-interface CollectionCreateSchemaWithSrc extends BaseCollectionCreateSchema {
+interface CollectionCreateSchemaWithSrc
+  extends Pick<BaseCollectionCreateSchema, "name"> {
   fields?: CollectionFieldSchema[];
 }
 


### PR DESCRIPTION
## Change Summary
### What is this?
This change improves the type safety and developer experience when creating collections in Typesense by introducing a more precise type  for the collection creation schema. The motivation came from issue #149 where the `fields` property was incorrectly marked as optional in all cases, when in reality it should only be optional when creating a collection with a source (`src_name`).

### Changes
#### Type System Improvements:
1. **In `Collections.ts`**:
   - Introduced `BaseCollectionCreateSchema` interface containing common collection properties
   - Created discriminated union type for `CollectionCreateSchema` that enforces:
     - When `src_name` is provided: `fields` property is not optional
     - When `src_name` is not provided: `fields` property is required
   - Added generic type parameter for better type inference with `CollectionCreateOptions`

#### Code Structure:
1. **In `Collections.ts`**:
   - Split the original `CollectionCreateSchema` into:
     - `BaseCollectionCreateSchema`: Common properties for all collections
     - `CollectionCreateSchemaWithoutSrc`: Schema requiring `fields` property
     - `CollectionCreateSchema<Options>`: Generic type that conditionally requires fields
   - Updated `create` method signature to leverage new type system:
     ```typescript
     async create<const Options extends CollectionCreateOptions>(
       schema: CollectionCreateSchema<Options>,
       options?: Options
     )
     ```
     - The [`const`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-0.html#const-type-parameters) modifier makes the Typescript compiler infer the generic as if it were an object with `as const`, making it a readonly constant, leading to proper inference. This iterates on #151, where the Generic needed to be defined by the consumer.

### Demo
```typescript
// Example 1: Creating a collection with source (fields property is optional)
client.collections().create(
  {
    name: "Giannis",
    // fields property not required when src_name is provided
  },
  { src_name: "source1" }
); // ✅ Valid

// Example 2: Creating a collection without source (fields property required)
client.collections().create({
  name: "Giannis",
}); // ❌ Error: Property 'fields' is required

// Example 3: Correct usage without source
client.collections().create({
  name: "Giannis",
  fields: [
    {
      name: "name",
      type: "string"
    }
  ]
}); // ✅ Valid
```

### Context
This change addresses issue #149 where the type system didn't correctly represent Typesense's behavior regarding collection creation. When creating a collection from a source (`src_name`), the `fields` property should not be required as the schema is inferred from the source. In all other cases, `fields` must be specified to define the collection's structure.


## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
