### PR TITLE
Add union response type support for multi-search requests

### DIFF
--- a/src/Typesense/MultiSearch.ts
+++ b/src/Typesense/MultiSearch.ts
@@ -70,6 +70,7 @@ export default class MultiSearch {
     const queryParams = { ...commonParams, ...additionalQueryParams };
 
     const normalizedSearchRequests = {
+      ...searchRequests,
       searches: searchRequests.searches.map(normalizeArrayableParams),
     };
 

--- a/src/Typesense/MultiSearch.ts
+++ b/src/Typesense/MultiSearch.ts
@@ -6,6 +6,7 @@ import {
   SearchParams,
   SearchParamsWithPreset,
   SearchResponse,
+  SearchResponseRequestParams,
 } from "./Documents";
 import { normalizeArrayableParams } from "./Utils";
 
@@ -23,16 +24,28 @@ export interface MultiSearchRequestWithPresetSchema
   "x-typesense-api-key"?: string;
 }
 
-export interface MultiSearchRequestsSchema {
-  union?: true;
+export interface MultiSearchRequestsSchema<
+  U extends boolean | undefined = undefined,
+> {
+  union?: U;
   searches: (MultiSearchRequestSchema | MultiSearchRequestWithPresetSchema)[];
 }
 
-export interface MultiSearchResponse<T extends DocumentSchema[] = []> {
-  results: { [Index in keyof T]: SearchResponse<T[Index]> } & {
-    length: T["length"];
-  };
+export interface UnionSearchResponse<T extends DocumentSchema>
+  extends Omit<SearchResponse<T>, "request_params"> {
+  union_request_params: SearchResponseRequestParams[];
 }
+
+type MultiSearchResponse<
+  U extends boolean | undefined,
+  T extends DocumentSchema[],
+> = U extends true
+  ? UnionSearchResponse<T[number]>
+  : {
+      results: { [Index in keyof T]: SearchResponse<T[Index]> } & {
+        length: T["length"];
+      };
+    };
 
 export default class MultiSearch {
   private requestWithCache: RequestWithCache;
@@ -40,7 +53,7 @@ export default class MultiSearch {
   constructor(
     private apiCall: ApiCall,
     private configuration: Configuration,
-    private useTextContentType: boolean = false
+    private useTextContentType: boolean = false,
   ) {
     this.requestWithCache = new RequestWithCache();
   }
@@ -49,14 +62,17 @@ export default class MultiSearch {
     this.requestWithCache.clearCache();
   }
 
-  async perform<T extends DocumentSchema[] = []>(
-    searchRequests: MultiSearchRequestsSchema,
+  async perform<
+    T extends DocumentSchema[] = [],
+    const U extends boolean | undefined = undefined,
+  >(
+    searchRequests: MultiSearchRequestsSchema<U>,
     commonParams: Partial<MultiSearchRequestSchema> = {},
     {
       cacheSearchResultsForSeconds = this.configuration
         .cacheSearchResultsForSeconds,
-    }: { cacheSearchResultsForSeconds?: number } = {}
-  ): Promise<MultiSearchResponse<T>> {
+    }: { cacheSearchResultsForSeconds?: number } = {},
+  ): Promise<MultiSearchResponse<U, T>> {
     const additionalHeaders = {};
     if (this.useTextContentType) {
       additionalHeaders["content-type"] = "text/plain";
@@ -86,6 +102,6 @@ export default class MultiSearch {
         additionalHeaders,
       ],
       { cacheResponseForSeconds: cacheSearchResultsForSeconds },
-    ) as Promise<MultiSearchResponse<T>>;
+    ) as Promise<MultiSearchResponse<U, T>>;
   }
 }


### PR DESCRIPTION
### TLDR
Improve TypeScript types for multi-search union responses and fix parameter normalization

## Change Summary
### What is this?
- Currently, when using `union: true` in multi-search requests, the response type doesn't properly reflect the unified structure of the results
- This change adds proper type support for union responses and fixes a bug in parameter normalization
- Developers will now get correct TypeScript type inference when using union searches

### Changes
#### Added Features:
1. **New Types in `MultiSearch.ts`**:
   - `UnionSearchResponse<T>`: New type to handle unified search responses, extending base `SearchResponse` but replacing `request_params` with `union_request_params`
   - `MultiSearchRequestsSchema<U>`: Made generic to support type inference based on union flag

#### Code Changes:
1. **In `MultiSearch.ts`**:
   - Modified `perform` method to support conditional response types based on union flag
   - Fixed parameter normalization by spreading search requests before processing
   - Updated type definitions to properly handle union vs non-union responses
   - Added type inference for `union_request_params` when union is true

### Demo
```typescript
// Regular multi-search (no union)
const standardSearch = await client.multiSearch.perform({
  searches: [
    {
      q: "phone",
      collection: "products"
    },
    {
      q: "laptop",
      collection: "electronics"
    }
  ]
});
// Type: 
// results: {
//   0: SearchResponse<Product>,
//   1: SearchResponse<Electronic>,
//   length: 2
// }

// Union multi-search
const unionSearch = await client.multiSearch.perform({
  union: true,
  searches: [
    {
      q: "phone",
      collection: "products"
    },
    {
      q: "laptop",
      collection: "electronics"
    }
  ]
});
// Type:
// results: UnionSearchResponse<Product | Electronic> with:
// - union_request_params: SearchResponseRequestParams[]
// - hits: SearchResponseHit<Product | Electronic>[]
```

### Context
The spreading of the parameters object is needed to address #265, since we didn't pass the whole object originally, but just the `searches` key.

The rest of the changes aim to give a better DX and avoid potential type issues and unions.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
