### PR TITLE
Make MultiSearchResponse public again

### DIFF
--- a/src/Typesense/MultiSearch.ts
+++ b/src/Typesense/MultiSearch.ts
@@ -36,7 +36,7 @@ export interface UnionSearchResponse<T extends DocumentSchema>
   union_request_params: SearchResponseRequestParams[];
 }
 
-type MultiSearchResponse<
+export type MultiSearchResponse<
   U extends boolean | undefined,
   T extends DocumentSchema[],
 > = U extends true


### PR DESCRIPTION
## Change Summary
This type was made private in https://github.com/typesense/typesense-js/pull/266

## PR Checklist
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
