### PR TITLE
fix(types): correct type reference in CollectionFieldSchema

### DIFF
--- a/src/Typesense/Collection.ts
+++ b/src/Typesense/Collection.ts
@@ -1,5 +1,9 @@
 import ApiCall from "./ApiCall";
-import Collections, { CollectionCreateSchema } from "./Collections";
+import Collections from "./Collections";
+import type {
+  BaseCollectionCreateSchema,
+  CollectionCreateSchema,
+} from "./Collections";
 import Documents, { DocumentSchema } from "./Documents";
 import { ObjectNotFound } from "./Errors";
 import Overrides from "./Overrides";
@@ -30,7 +34,7 @@ export type FieldType =
 
 export interface CollectionFieldSchema
   extends Partial<
-    Pick<CollectionCreateSchema, "token_separators" | "symbols_to_index">
+    Pick<BaseCollectionCreateSchema, "token_separators" | "symbols_to_index">
   > {
   name: string;
   type: FieldType;

--- a/src/Typesense/Collections.ts
+++ b/src/Typesense/Collections.ts
@@ -1,7 +1,7 @@
 import ApiCall from "./ApiCall";
 import type { CollectionFieldSchema, CollectionSchema } from "./Collection";
 
-interface BaseCollectionCreateSchema {
+export interface BaseCollectionCreateSchema {
   name: string;
   default_sorting_field?: string;
   symbols_to_index?: string[];


### PR DESCRIPTION


## Change Summary
<!--- Described your changes here -->

Addresses #269.

This pull request includes several changes to the `Typesense` module to improve type definitions and imports. The most important changes include modifying type imports in `Collection.ts` and exporting the `BaseCollectionCreateSchema` interface in `Collections.ts`.

Improvements to type definitions and imports:

* [`src/Typesense/Collection.ts`](diffhunk://#diff-6899637b797621e4136afa78180b0c9ea379fb9cdf50a521569fd6f33d85ec8dL2-R6): Modified imports to separately import `BaseCollectionCreateSchema` and `CollectionCreateSchema` from `Collections.ts`.
* [`src/Typesense/Collection.ts`](diffhunk://#diff-6899637b797621e4136afa78180b0c9ea379fb9cdf50a521569fd6f33d85ec8dL33-R37): Updated `CollectionFieldSchema` to use `BaseCollectionCreateSchema` instead of `CollectionCreateSchema` for `token_separators` and `symbols_to_index` properties.
* [`src/Typesense/Collections.ts`](diffhunk://#diff-36b3201c887bcfa5004dba3ecf2de37d438b526bf029f280290a35098a2cf9c2L4-R4): Exported the `BaseCollectionCreateSchema` interface to allow its use in other files.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
