### PR TITLE
types: add `parent` key in the `facet_count` response

### DIFF
--- a/src/Typesense/Documents.ts
+++ b/src/Typesense/Documents.ts
@@ -81,6 +81,7 @@ export interface SearchResponseFacetCountSchema<T extends DocumentSchema> {
     count: number;
     highlighted: string;
     value: string;
+    parent?: Record<string, string | number | boolean>;
   }[];
   field_name: keyof T;
   stats: {


### PR DESCRIPTION
## Change Summary
Add a `parent` optional key  in the `facet_count` response type, for when faceting by children fields and want to return their parent in full. Closes #275 

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
