### PR TITLE
Add missing fields to SearchResponseFacetCountSchema interface

### DIFF
--- a/src/Typesense/Documents.ts
+++ b/src/Typesense/Documents.ts
@@ -89,11 +89,13 @@ export interface SearchResponseFacetCountSchema<T extends DocumentSchema> {
     parent?: Record<string, string | number | boolean>;
   }[];
   field_name: keyof T;
+  sampled: boolean;
   stats: {
     avg?: number;
     max?: number;
     min?: number;
     sum?: number;
+    total_values?: number;
   };
 }
 


### PR DESCRIPTION
## Change Summary
Missing fields `sampled` and `stats.total_values` to the Interface
![image](https://github.com/user-attachments/assets/e6f34fb1-199f-4518-8431-2cd999c2e650)


## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
