### PR TITLE
feat(keys): add template types for key actions

### DIFF
--- a/src/Typesense/Key.ts
+++ b/src/Typesense/Key.ts
@@ -2,7 +2,7 @@ import ApiCall from "./ApiCall";
 import Keys from "./Keys";
 
 export interface KeyCreateSchema {
-  actions: string[];
+  actions: Actions[];
   collections: string[];
   description?: string;
   value?: string;
@@ -10,6 +10,39 @@ export interface KeyCreateSchema {
   expires_at?: number;
   autodelete?: boolean;
 }
+
+type CRUDActions = "create" | "delete" | "get" | "list" | "*";
+type DocumentActionTypes =
+  | "search"
+  | "get"
+  | "create"
+  | "upsert"
+  | "update"
+  | "delete"
+  | "import"
+  | "export"
+  | "*";
+
+type CRUDFeatures =
+  | "collections"
+  | "aliases"
+  | "synonyms"
+  | "overrides"
+  | "stopwords"
+  | "keys"
+  | "analytics"
+  | "analytics/rules";
+
+type FeatureActions = `${CRUDFeatures}:${CRUDActions}`;
+type DocumentActions = `documents:${DocumentActionTypes}`;
+type AnalyticsEventActions = "analytics/events:create";
+type MiscActions = `${`metrics.json` | `stats.json` | `debug`}.list` | "*";
+
+export type Actions =
+  | FeatureActions
+  | DocumentActions
+  | AnalyticsEventActions
+  | MiscActions;
 
 export interface KeyDeleteSchema {
   id: number;


### PR DESCRIPTION
### TLDR
Added TypeScript [template literal](https://www.typescriptlang.org/docs/handbook/2/template-literal-types.html)  types for Typesense API key actions validation.

## Change Summary

#### Type System Improvements:
1. **New Type Definitions in `Key.ts`**:
   - `Actions`: Union type combining all valid action patterns using template literals
   - `CRUDActions`: Basic CRUD operations (`create`, `delete`, `get`, `list`, `*`)
   - `DocumentActionTypes`: Document-specific operations (`search`, `upsert`, `import`, `export`, etc.)
   - `CRUDFeatures`: Typesense feature categories (`collections`, `aliases`, `synonyms`, etc.)

#### Code Changes:
1. **In `Key.ts`**:
   - **`KeyCreateSchema` interface**: Changed `actions` property from `string[]` to `Actions[]` for type safety
   - **Template literal types**: Created `FeatureActions` as `${CRUDFeatures}:${CRUDActions}` pattern
   - **Specialized action types**: Added `DocumentActions`, `AnalyticsEventActions`, and `MiscActions` for specific use cases

### Context
This change replaces the generic `string[]` type for API key actions with strongly-typed template literal types that match Typesense's actual API action patterns. This provides better LSP support and compile-time validation for developers creating API keys, preventing invalid action specifications.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
