### PR TITLE
chore(types): add default generic param for infix in search params

### DIFF
--- a/src/Typesense/Types.ts
+++ b/src/Typesense/Types.ts
@@ -95,7 +95,7 @@ export const arrayableParams: ArraybleParams = {
 
 export interface SearchParams<
   TDoc extends DocumentSchema,
-  Infix extends string,
+  Infix extends string = string,
 > {
   // From https://typesense.org/docs/latest/api/documents.html#arguments
   // eslint-disable-next-line @typescript-eslint/ban-types -- Can't use `object` here, it needs to intersect with `{}`


### PR DESCRIPTION
## Change Summary
Add a default `string` param to avoid type errors when defining a var to be of type `SearchParams`

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
