### PR TITLE
feat(types): add natural language query debug and caching support

### DIFF
--- a/src/Typesense/Documents.ts
+++ b/src/Typesense/Documents.ts
@@ -101,6 +101,12 @@ export interface SearchResponseFacetCountSchema<T extends DocumentSchema> {
   };
 }
 
+interface LLMResponse {
+  content: string;
+  extraction_method: string;
+  model: string;
+}
+
 // Todo: we could infer whether this is a grouped response by adding the search params as a generic
 export interface SearchResponse<T extends DocumentSchema> {
   facet_counts?: SearchResponseFacetCountSchema<T>[];
@@ -117,6 +123,12 @@ export interface SearchResponse<T extends DocumentSchema> {
     hits: SearchResponseHit<T>[];
     found?: number;
   }[];
+  parsed_nl_query?: {
+    parse_time_ms: number;
+    generated_params: SearchParams<T>;
+    augmented_params: SearchParams<T>;
+    llm_response?: LLMResponse;
+  };
   conversation?: {
     answer: string;
     conversation_history: {

--- a/src/Typesense/Types.ts
+++ b/src/Typesense/Types.ts
@@ -134,6 +134,8 @@ export interface SearchParams<
   snippet_threshold?: number; // default: 30
   nl_query?: boolean;
   nl_model_id?: string;
+  nl_query_debug?: boolean;
+  nl_query_prompt_cache_ttl?: number;
   num_typos?: string | number | number[]; // default: 2
   min_len_1typo?: number;
   min_len_2typo?: number;


### PR DESCRIPTION
## Change Summary
- add `LLMResponse` interface for llm response structure
- add `parsed_nl_query` field to `SearchResponse` with debug info
- add `nl_query_debug` parameter to enable nl query debugging
- add `nl_query_prompt_cache_ttl` parameter for prompt caching


<!--- Described your changes here -->

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
