### PR TITLE
add `geo_distance_meters` to SearchResponseHit<T> type

### DIFF
--- a/lib/Typesense/Documents.d.ts
+++ b/lib/Typesense/Documents.d.ts
@@ -59,7 +59,7 @@ export interface SearchResponseHit<T extends DocumentSchema> {
         score: `${number}`;
         tokens_matched: number;
     };
-    geo_distance_meters: {
+    geo_distance_meters?: {
         location: number
     };
 }

--- a/lib/Typesense/Documents.d.ts
+++ b/lib/Typesense/Documents.d.ts
@@ -59,6 +59,9 @@ export interface SearchResponseHit<T extends DocumentSchema> {
         score: `${number}`;
         tokens_matched: number;
     };
+    geo_distance_meters: {
+        location: number
+    };
 }
 export interface SearchResponseFacetCountSchema<T extends DocumentSchema> {
     counts: {

--- a/src/Typesense/Documents.ts
+++ b/src/Typesense/Documents.ts
@@ -81,6 +81,9 @@ export interface SearchResponseHit<T extends DocumentSchema> {
     score: `${number}`; // To prevent scores from being truncated by JSON spec
     tokens_matched: number;
   };
+  geo_distance_meters?: {
+    location: number
+  };
 }
 
 export interface SearchResponseFacetCountSchema<T extends DocumentSchema> {


### PR DESCRIPTION
### Description

This PR adds support for the optional `geo_distance_meters` field to the `SearchResponseHit<T>` type in the Typesense Node.js SDK.

`geo_distance_meters` is returned by the Typesense search API when a `sort_by=location(...)` clause is included in the search parameters. However, this field is currently missing from the TypeScript definition of `SearchResponseHit<T>`, leading to type errors or the need for manual casting.

### Changes

- Added `geo_distance_meters?: number` to `SearchResponseHit<T>` interface in `Documents.ts`.

### Motivation

This change improves developer experience by:
- Providing accurate type information
- Preventing unnecessary `any` casts
- Enabling safe and clean usage of `geo_distance_meters` in strongly typed applications
