### PR TITLE
feat(documents): extend type defs for document deletion

### DIFF
--- a/src/Typesense/Documents.ts
+++ b/src/Typesense/Documents.ts
@@ -19,10 +19,14 @@ export type DeleteQuery =
       filter_by?: string;
       batch_size?: number;
       ignore_not_found?: boolean;
+      return_doc?: boolean;
+      return_id?: boolean;
     };
 
-export interface DeleteResponse {
+export interface DeleteResponse<T extends DocumentSchema = DocumentSchema> {
   num_deleted: number;
+  documents?: T[];
+  ids?: string[];
 }
 
 interface ImportResponseSuccess {
@@ -239,8 +243,8 @@ export default class Documents<T extends DocumentSchema = object>
 
   async delete(
     query: DeleteQuery = {} as DeleteQuery,
-  ): Promise<DeleteResponse> {
-    return this.apiCall.delete<DeleteResponse>(this.endpointPath(), query);
+  ): Promise<DeleteResponse<T>> {
+    return this.apiCall.delete<DeleteResponse<T>>(this.endpointPath(), query);
   }
 
   async createMany(documents: T[], options: DocumentImportParameters = {}) {


### PR DESCRIPTION
## Change Summary
- updated `DeleteResponse` to be generic over document schema
- included typed `documents` field in response when `return_doc` is true
- updated `delete()` method to return `DeleteResponse<T>` for better typings


<!--- Described your changes here -->

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
