### PR TITLE
feat: add warning for individual pagination with union search

### DIFF
--- a/src/Typesense/ApiCall.ts
+++ b/src/Typesense/ApiCall.ts
@@ -103,7 +103,7 @@ export default class ApiCall implements HttpClient {
   private readonly numRetriesPerRequest: number;
   private readonly additionalUserHeaders?: Record<string, string>;
 
-  private readonly logger: Logger;
+  readonly logger: Logger;
   private currentNodeIndex: number;
 
   constructor(private configuration: Configuration) {


### PR DESCRIPTION
## Change Summary

- expose logger property in apicall and multisearch classes
- warn when individual search pagination parameters are used with union: true
- add helper method to detect pagination parameters in search objects
- add test for warning scenarios


<!--- Described your changes here -->

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
