### PR TITLE
feat(synonyms): add support for V30 synonyms

### DIFF
--- a/doc/examples/server/synonymSets.ts
+++ b/doc/examples/server/synonymSets.ts
@@ -1,0 +1,65 @@
+import { Client } from "../../src/Typesense";
+
+const client = new Client({
+  nodes: [
+    {
+      host: "localhost",
+      port: 8108,
+      protocol: "http",
+    },
+  ],
+  apiKey: "xyz",
+  connectionTimeoutSeconds: 2,
+});
+
+async function synonymSetsExample(): Promise<void> {
+  try {
+    // Create a synonym set
+    const synonymSet = await client.synonymSets().upsert({
+      name: "foobar",
+      synonyms: [
+        {
+          id: "dummy",
+          synonyms: ["foo", "bar", "baz"],
+        },
+      ],
+    });
+    console.log("Created synonym set:", synonymSet);
+
+    // Retrieve all synonym sets
+    const allSynonymSets = await client.synonymSets().retrieve();
+    console.log("All synonym sets:", allSynonymSets);
+
+    // Get a specific synonym set
+    const specificSynonymSet = await client.synonymSets("foobar").retrieve();
+    console.log("Specific synonym set:", specificSynonymSet);
+
+    // Create a collection with synonym sets
+    const collection = await client.collections().create({
+      name: "products",
+      fields: [
+        {
+          name: "name",
+          type: "string",
+        },
+      ],
+      synonym_sets: ["foobar", "index1", "index2"],
+    });
+    console.log("Created collection with synonym sets:", collection);
+
+    // Update a collection to add synonym sets
+    const updatedCollection = await client.collections("products").update({
+      synonym_sets: ["foobar", "index1", "index2", "index3"],
+    });
+    console.log("Updated collection:", updatedCollection);
+
+    // Delete a synonym set
+    const deletedSynonymSet = await client.synonymSets("foobar").delete();
+    console.log("Deleted synonym set:", deletedSynonymSet);
+  } catch (error) {
+    console.error("Error:", error);
+  }
+}
+
+// Run the example
+synonymSetsExample();

--- a/src/Typesense/Client.ts
+++ b/src/Typesense/Client.ts
@@ -24,6 +24,8 @@ import Conversation from "./Conversation";
 import Stemming from "./Stemming";
 import NLSearchModels from "./NLSearchModels";
 import NLSearchModel from "./NLSearchModel";
+import SynonymSets from "./SynonymSets";
+import SynonymSet from "./SynonymSet";
 
 export default class Client {
   configuration: Configuration;
@@ -50,6 +52,8 @@ export default class Client {
   private readonly individualConversations: Record<string, Conversation>;
   private readonly _nlSearchModels: NLSearchModels;
   private readonly individualNLSearchModels: Record<string, NLSearchModel>;
+  private readonly _synonymSets: SynonymSets;
+  private readonly individualSynonymSets: Record<string, SynonymSet>;
 
   constructor(options: ConfigurationOptions) {
     options.sendApiKeyAsQueryParam = options.sendApiKeyAsQueryParam ?? false;
@@ -78,6 +82,8 @@ export default class Client {
     this.individualConversations = {};
     this._nlSearchModels = new NLSearchModels(this.apiCall);
     this.individualNLSearchModels = {};
+    this._synonymSets = new SynonymSets(this.apiCall);
+    this.individualSynonymSets = {};
   }
 
   collections(): Collections;
@@ -174,6 +180,22 @@ export default class Client {
         this.individualNLSearchModels[id] = new NLSearchModel(id, this.apiCall);
       }
       return this.individualNLSearchModels[id];
+    }
+  }
+
+  synonymSets(): SynonymSets;
+  synonymSets(synonymSetName: string): SynonymSet;
+  synonymSets(synonymSetName?: string): SynonymSets | SynonymSet {
+    if (synonymSetName === undefined) {
+      return this._synonymSets;
+    } else {
+      if (this.individualSynonymSets[synonymSetName] === undefined) {
+        this.individualSynonymSets[synonymSetName] = new SynonymSet(
+          synonymSetName,
+          this.apiCall,
+        );
+      }
+      return this.individualSynonymSets[synonymSetName];
     }
   }
 }

--- a/src/Typesense/Collection.ts
+++ b/src/Typesense/Collection.ts
@@ -65,6 +65,7 @@ export interface CollectionDropFieldSchema {
 export interface CollectionUpdateSchema
   extends Partial<Omit<CollectionCreateSchema, "name" | "fields">> {
   fields?: (CollectionFieldSchema | CollectionDropFieldSchema)[];
+  synonym_sets?: string[];
 }
 
 export interface CollectionDeleteOptions {

--- a/src/Typesense/Collections.ts
+++ b/src/Typesense/Collections.ts
@@ -11,6 +11,7 @@ export interface BaseCollectionCreateSchema {
   voice_query_model?: {
     model_name?: string;
   };
+  synonym_sets?: string[];
 }
 
 interface CollectionCreateSchemaWithSrc

--- a/src/Typesense/SynonymSet.ts
+++ b/src/Typesense/SynonymSet.ts
@@ -1,0 +1,34 @@
+import ApiCall from "./ApiCall";
+import SynonymSets from "./SynonymSets";
+import type { SynonymSetCreateSchema, SynonymSetSchema } from "./SynonymSets";
+
+export interface SynonymSetDeleteSchema {
+  name: string;
+}
+
+export type SynonymSetRetrieveSchema = SynonymSetCreateSchema;
+
+export default class SynonymSet {
+  constructor(
+    private synonymSetName: string,
+    private apiCall: ApiCall,
+  ) {}
+
+  async upsert(
+    params: SynonymSetCreateSchema,
+  ): Promise<SynonymSetCreateSchema> {
+    return this.apiCall.put<SynonymSetSchema>(this.endpointPath(), params);
+  }
+
+  async retrieve(): Promise<SynonymSetRetrieveSchema> {
+    return this.apiCall.get<SynonymSetRetrieveSchema>(this.endpointPath());
+  }
+
+  async delete(): Promise<SynonymSetDeleteSchema> {
+    return this.apiCall.delete<SynonymSetDeleteSchema>(this.endpointPath());
+  }
+
+  private endpointPath(): string {
+    return `${SynonymSets.RESOURCEPATH}/${encodeURIComponent(this.synonymSetName)}`;
+  }
+}

--- a/src/Typesense/SynonymSets.ts
+++ b/src/Typesense/SynonymSets.ts
@@ -1,0 +1,30 @@
+import ApiCall from "./ApiCall";
+
+export interface SynonymItemSchema {
+  id: string;
+  synonyms: string[];
+  root?: string;
+  locale?: string;
+  symbols_to_index?: string[];
+}
+
+export interface SynonymSetCreateSchema {
+  synonyms: SynonymItemSchema[];
+}
+
+export interface SynonymSetSchema extends SynonymSetCreateSchema {
+  name: string;
+}
+
+export interface SynonymSetsRetrieveSchema {
+  synonym_sets: SynonymSetSchema[];
+}
+
+export default class SynonymSets {
+  constructor(private apiCall: ApiCall) {}
+  static readonly RESOURCEPATH = "/synonym_sets";
+
+  async retrieve(): Promise<SynonymSetSchema[]> {
+    return this.apiCall.get<SynonymSetSchema[]>(SynonymSets.RESOURCEPATH);
+  }
+}

--- a/src/Typesense/Types.ts
+++ b/src/Typesense/Types.ts
@@ -90,6 +90,7 @@ export const arrayableParams: ArraybleParams = {
   override_tags: "override_tags",
   num_typos: "num_typos",
   prefix: "prefix",
+  synonym_sets: "synonym_sets",
   sort_by: "sort_by",
 };
 
@@ -145,6 +146,7 @@ export interface SearchParams<
   drop_tokens_mode?: DropTokensMode;
   typo_tokens_threshold?: number; // default: 100
   pinned_hits?: string | string[];
+  synonym_sets?: string[] | string;
   hidden_hits?: string | string[];
   limit_hits?: number; // default: no limit
   pre_segmented_query?: boolean;

--- a/test/Typesense/AnalyticsEvents.spec.ts
+++ b/test/Typesense/AnalyticsEvents.spec.ts
@@ -1,20 +1,21 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { Client as TypesenseClient } from "../../src/Typesense";
 import { ObjectNotFound } from "../../src/Typesense/Errors";
+import { isV30OrAbove } from "../utils";
 
-describe("AnalyticsEvents", function () {
-  const typesense = new TypesenseClient({
-    nodes: [
-      {
-        host: "localhost",
-        port: 8108,
-        protocol: "http",
-      },
-    ],
-    apiKey: "xyz",
-    connectionTimeoutSeconds: 180,
-  });
+const typesense = new TypesenseClient({
+  nodes: [
+    {
+      host: "localhost",
+      port: 8108,
+      protocol: "http",
+    },
+  ],
+  apiKey: "xyz",
+  connectionTimeoutSeconds: 180,
+});
 
+describe.skipIf(await isV30OrAbove(typesense))("AnalyticsEvents", function () {
   const analyticsEvents = typesense.analytics.events();
 
   beforeAll(async function () {

--- a/test/Typesense/AnalyticsRule.spec.ts
+++ b/test/Typesense/AnalyticsRule.spec.ts
@@ -5,20 +5,21 @@ import {
   ObjectAlreadyExists,
 } from "../../src/Typesense/Errors";
 import { AnalyticsRuleCreateSchema } from "../../src/Typesense/AnalyticsRule";
+import { isV30OrAbove } from "../utils";
 
-describe("AnalyticsRule", function () {
-  const typesense = new TypesenseClient({
-    nodes: [
-      {
-        host: "localhost",
-        port: 8108,
-        protocol: "http",
-      },
-    ],
-    apiKey: "xyz",
-    connectionTimeoutSeconds: 180,
-  });
+const typesense = new TypesenseClient({
+  nodes: [
+    {
+      host: "localhost",
+      port: 8108,
+      protocol: "http",
+    },
+  ],
+  apiKey: "xyz",
+  connectionTimeoutSeconds: 180,
+});
 
+describe.skipIf(await isV30OrAbove(typesense))("AnalyticsRule", function () {
   const testRuleName = "test_analytics_rule";
   const testRuleData = {
     type: "popular_queries",

--- a/test/Typesense/AnalyticsRules.spec.ts
+++ b/test/Typesense/AnalyticsRules.spec.ts
@@ -5,20 +5,21 @@ import {
   ObjectAlreadyExists,
 } from "../../src/Typesense/Errors";
 import { AnalyticsRuleCreateSchema } from "../../src/Typesense/AnalyticsRule";
+import { isV30OrAbove } from "../utils";
 
-describe("AnalyticsRules", function () {
-  const typesense = new TypesenseClient({
-    nodes: [
-      {
-        host: "localhost",
-        port: 8108,
-        protocol: "http",
-      },
-    ],
-    apiKey: "xyz",
-    connectionTimeoutSeconds: 180,
-  });
+const typesense = new TypesenseClient({
+  nodes: [
+    {
+      host: "localhost",
+      port: 8108,
+      protocol: "http",
+    },
+  ],
+  apiKey: "xyz",
+  connectionTimeoutSeconds: 180,
+});
 
+describe.skipIf(await isV30OrAbove(typesense))("AnalyticsRules", function () {
   const analyticsRules = typesense.analytics.rules();
   const testRuleName = "search_suggestions";
   const testRuleData = {

--- a/test/Typesense/Synonym.spec.ts
+++ b/test/Typesense/Synonym.spec.ts
@@ -1,20 +1,21 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Client as TypesenseClient } from "../../src/Typesense";
 import { ObjectNotFound } from "../../src/Typesense/Errors";
+import { isV30OrAbove } from "../utils";
 
-describe("Synonym", function () {
-  const typesense = new TypesenseClient({
-    nodes: [
-      {
-        host: "localhost",
-        port: 8108,
-        protocol: "http",
-      },
-    ],
-    apiKey: "xyz",
-    connectionTimeoutSeconds: 180,
-  });
+const typesense = new TypesenseClient({
+  nodes: [
+    {
+      host: "localhost",
+      port: 8108,
+      protocol: "http",
+    },
+  ],
+  apiKey: "xyz",
+  connectionTimeoutSeconds: 180,
+});
 
+describe.skipIf(await isV30OrAbove(typesense))("Synonym", function () {
   const testCollectionName = "test_companies_synonym";
   const testSynonymId = "synonym-set-1";
   const synonymData = {

--- a/test/Typesense/SynonymSet.spec.ts
+++ b/test/Typesense/SynonymSet.spec.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Client as TypesenseClient } from "../../src/Typesense";
+import { ObjectNotFound } from "../../src/Typesense/Errors";
+import { isV30OrAbove } from "../utils";
+
+const typesense = new TypesenseClient({
+  nodes: [
+    {
+      host: "localhost",
+      port: 8108,
+      protocol: "http",
+    },
+  ],
+  apiKey: "xyz",
+  connectionTimeoutSeconds: 180,
+});
+
+describe.skipIf(!(await isV30OrAbove(typesense)))("SynonymSet", function () {
+  const testSynonymSetName = "test-synonym-set";
+  const synonymSetData = {
+    synonyms: [
+      {
+        id: "dummy",
+        synonyms: ["foo", "bar", "baz"],
+      },
+    ],
+  };
+
+  beforeEach(async function () {
+    try {
+      await typesense.synonymSets(testSynonymSetName).delete();
+    } catch (error) {
+      // Ignore if synonym set doesn't exist
+    }
+  });
+
+  afterEach(async function () {
+    try {
+      await typesense.synonymSets(testSynonymSetName).delete();
+    } catch (error) {
+      if (!(error instanceof ObjectNotFound)) {
+        console.warn("Failed to cleanup test synonym set:", error);
+      }
+    }
+  });
+
+  describe(".upsert", function () {
+    it("creates the synonym set", async function () {
+      const createResult = await typesense
+        .synonymSets(testSynonymSetName)
+        .upsert(synonymSetData);
+
+      expect(createResult).toBeDefined();
+      expect(createResult.synonyms[0].id).toBe("dummy");
+      expect(createResult.synonyms).toMatchObject(synonymSetData.synonyms);
+    });
+  });
+
+  describe(".retrieve", function () {
+    it("retrieves a specific synonym set", async function () {
+      await typesense.synonymSets(testSynonymSetName).upsert(synonymSetData);
+
+      const retrievedSynonymSet = await typesense
+        .synonymSets(testSynonymSetName)
+        .retrieve();
+
+      expect(retrievedSynonymSet).toBeDefined();
+      expect(retrievedSynonymSet.synonyms[0].id).toBe("dummy");
+      expect(retrievedSynonymSet.synonyms).toMatchObject(
+        synonymSetData.synonyms,
+      );
+    });
+  });
+
+  describe(".delete", function () {
+    it("deletes a specific synonym set", async function () {
+      await typesense.synonymSets(testSynonymSetName).upsert(synonymSetData);
+
+      const deleteResult = await typesense
+        .synonymSets(testSynonymSetName)
+        .delete();
+
+      expect(deleteResult).toBeDefined();
+      expect(deleteResult.name).toBe(testSynonymSetName);
+
+      await expect(
+        typesense.synonymSets(testSynonymSetName).retrieve(),
+      ).rejects.toThrow(ObjectNotFound);
+    });
+  });
+});

--- a/test/Typesense/SynonymSets.spec.ts
+++ b/test/Typesense/SynonymSets.spec.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Client as TypesenseClient } from "../../src/Typesense";
+import { ObjectNotFound } from "../../src/Typesense/Errors";
+import { isV30OrAbove } from "../utils";
+
+const typesense = new TypesenseClient({
+  nodes: [
+    {
+      host: "localhost",
+      port: 8108,
+      protocol: "http",
+    },
+  ],
+  apiKey: "xyz",
+  connectionTimeoutSeconds: 180,
+});
+
+describe.skipIf(!(await isV30OrAbove(typesense)))("SynonymSets", function () {
+  const testSynonymSetName = "test-synonym-set";
+  const synonymSetData = {
+    synonyms: [
+      {
+        id: "dummy",
+        synonyms: ["foo", "bar", "baz"],
+      },
+    ],
+  };
+
+  beforeEach(async function () {
+    try {
+      await typesense.synonymSets(testSynonymSetName).delete();
+    } catch (error) {
+      // Ignore if synonym set doesn't exist
+    }
+  });
+
+  afterEach(async function () {
+    try {
+      await typesense.synonymSets(testSynonymSetName).delete();
+    } catch (error) {
+      if (!(error instanceof ObjectNotFound)) {
+        console.warn("Failed to cleanup test synonym set:", error);
+      }
+    }
+  });
+
+  describe(".upsert", function () {
+    it("creates the synonym set", async function () {
+      const createResult = await typesense
+        .synonymSets(testSynonymSetName)
+        .upsert(synonymSetData);
+
+      expect(createResult).toBeDefined();
+      expect(createResult.synonyms[0].id).toBe("dummy");
+      expect(createResult.synonyms).toMatchObject(synonymSetData.synonyms);
+    });
+  });
+
+  describe(".retrieve", function () {
+    it("retrieves all synonym sets", async function () {
+      await typesense.synonymSets(testSynonymSetName).upsert(synonymSetData);
+
+      const allSynonymSets = await typesense.synonymSets().retrieve();
+
+      expect(allSynonymSets).toBeDefined();
+      expect(Array.isArray(allSynonymSets)).toBe(true);
+      expect(allSynonymSets.length).toBeGreaterThan(0);
+
+      const createdSynonymSet = allSynonymSets.find(
+        (synonymSet) => synonymSet.name === testSynonymSetName,
+      );
+
+      expect(createdSynonymSet).toBeDefined();
+      expect(createdSynonymSet?.synonyms).toMatchObject(
+        synonymSetData.synonyms,
+      );
+    });
+  });
+
+  describe("individual synonym set operations", function () {
+    it("retrieves a specific synonym set", async function () {
+      await typesense.synonymSets(testSynonymSetName).upsert(synonymSetData);
+
+      const retrievedSynonymSet = await typesense
+        .synonymSets(testSynonymSetName)
+        .retrieve();
+
+      expect(retrievedSynonymSet).toBeDefined();
+      expect(retrievedSynonymSet.synonyms[0].id).toBe("dummy");
+      expect(retrievedSynonymSet.synonyms).toMatchObject(
+        synonymSetData.synonyms,
+      );
+    });
+
+    it("deletes a specific synonym set", async function () {
+      await typesense.synonymSets(testSynonymSetName).upsert(synonymSetData);
+
+      const deleteResult = await typesense
+        .synonymSets(testSynonymSetName)
+        .delete();
+
+      expect(deleteResult).toBeDefined();
+      expect(deleteResult.name).toBe(testSynonymSetName);
+
+      await expect(
+        typesense.synonymSets(testSynonymSetName).retrieve(),
+      ).rejects.toThrow(ObjectNotFound);
+    });
+  });
+});

--- a/test/Typesense/SynonymSets.spec.ts
+++ b/test/Typesense/SynonymSets.spec.ts
@@ -44,18 +44,6 @@ describe.skipIf(!(await isV30OrAbove(typesense)))("SynonymSets", function () {
     }
   });
 
-  describe(".upsert", function () {
-    it("creates the synonym set", async function () {
-      const createResult = await typesense
-        .synonymSets(testSynonymSetName)
-        .upsert(synonymSetData);
-
-      expect(createResult).toBeDefined();
-      expect(createResult.synonyms[0].id).toBe("dummy");
-      expect(createResult.synonyms).toMatchObject(synonymSetData.synonyms);
-    });
-  });
-
   describe(".retrieve", function () {
     it("retrieves all synonym sets", async function () {
       await typesense.synonymSets(testSynonymSetName).upsert(synonymSetData);
@@ -74,37 +62,6 @@ describe.skipIf(!(await isV30OrAbove(typesense)))("SynonymSets", function () {
       expect(createdSynonymSet?.synonyms).toMatchObject(
         synonymSetData.synonyms,
       );
-    });
-  });
-
-  describe("individual synonym set operations", function () {
-    it("retrieves a specific synonym set", async function () {
-      await typesense.synonymSets(testSynonymSetName).upsert(synonymSetData);
-
-      const retrievedSynonymSet = await typesense
-        .synonymSets(testSynonymSetName)
-        .retrieve();
-
-      expect(retrievedSynonymSet).toBeDefined();
-      expect(retrievedSynonymSet.synonyms[0].id).toBe("dummy");
-      expect(retrievedSynonymSet.synonyms).toMatchObject(
-        synonymSetData.synonyms,
-      );
-    });
-
-    it("deletes a specific synonym set", async function () {
-      await typesense.synonymSets(testSynonymSetName).upsert(synonymSetData);
-
-      const deleteResult = await typesense
-        .synonymSets(testSynonymSetName)
-        .delete();
-
-      expect(deleteResult).toBeDefined();
-      expect(deleteResult.name).toBe(testSynonymSetName);
-
-      await expect(
-        typesense.synonymSets(testSynonymSetName).retrieve(),
-      ).rejects.toThrow(ObjectNotFound);
     });
   });
 });

--- a/test/Typesense/Synonyms.spec.ts
+++ b/test/Typesense/Synonyms.spec.ts
@@ -1,20 +1,21 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Client as TypesenseClient } from "../../src/Typesense";
 import { ObjectNotFound } from "../../src/Typesense/Errors";
+import { isV30OrAbove } from "../utils";
 
-describe("Synonyms", function () {
-  const typesense = new TypesenseClient({
-    nodes: [
-      {
-        host: "localhost",
-        port: 8108,
-        protocol: "http",
-      },
-    ],
-    apiKey: "xyz",
-    connectionTimeoutSeconds: 180,
-  });
+const typesense = new TypesenseClient({
+  nodes: [
+    {
+      host: "localhost",
+      port: 8108,
+      protocol: "http",
+    },
+  ],
+  apiKey: "xyz",
+  connectionTimeoutSeconds: 180,
+});
 
+describe.skipIf(await isV30OrAbove(typesense))("Synonyms", function () {
   const testCollectionName = "test_companies_synonyms";
   const testSynonymId = "synonym-set-1";
   const synonymData = {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,0 +1,10 @@
+import { Client } from "../src/Typesense";
+
+export async function isV30OrAbove(client: Client) {
+  const debug = await client.debug.retrieve();
+  if (debug.version === "nightly") {
+    return true;
+  }
+  const numberedVersion = debug.version.split("v")[1];
+  return Number(numberedVersion) >= 30;
+}


### PR DESCRIPTION
## TLDR
Introduce Synonym Sets support in the Typesense client with full API integration, test coverage, and example usage.

### Changes

#### Added Features:
1. **Client Support for Synonym Sets (`Client.ts`):**
   - `synonymSets()` method added to the `Client` class with overloads for retrieving all sets or accessing individual sets by name.
   - Internally maintains `_synonymSets` and `individualSynonymSets` for caching and reuse.

2. **Synonym Set Management Classes:**
   - **`SynonymSet.ts`**: Defines `SynonymSet` class to handle upsert, retrieve, and delete operations for a specific synonym set.
   - **`SynonymSets.ts`**: Manages operations for all synonym sets collectively.

3. **Collection Schema (`Collection.ts`, `Collections.ts`, `Types.ts`):**
   - Collection creation and update schemas now support a `synonym_sets` array.
   - `synonym_sets` is also supported in search parameters for more refined query behavior.

4. **Version Detection Utility (`utils.ts`):**
   - `isV30OrAbove()` function added to dynamically skip tests based on Typesense version (supports both nightly and stable v30+ builds).

#### Test Coverage:
1. **New Test Suite for Synonym Sets (`SynonymSets.spec.ts`):**
   - Tests CRUD operations: upsert, retrieve (all and individual), and delete.

2. **Conditional Skipping for Existing Tests:**
   - Tests for Analytics and Synonyms now use `describe.skipIf(await isV30OrAbove(...))` to conditionally skip based on version compatibility.

3. **Test Refactoring:**
   - Moved Typesense client initialization outside `describe()` blocks to reduce duplication.
   - Ensured all modified test files import the new version utility.

#### Documentation Updates:
1. **New TypeScript Example (`synonymSets.ts`):**
   - Demonstrates full usage lifecycle:
     - Create a synonym set
     - Retrieve all/specific sets
     - Attach synonym sets to collections during creation and update
     - Delete a synonym set


## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
