### PR TITLE
feat(types): add potential `metadata` prop to search response type

### DIFF
--- a/src/Typesense/Documents.ts
+++ b/src/Typesense/Documents.ts
@@ -154,7 +154,14 @@ export interface SearchResponse<T extends DocumentSchema> {
   };
   error?: string;
   code?: number;
+  metadata?: JsonRecord;
 }
+
+type JSONPrimitive = string | number | boolean | null;
+
+type JsonRecord = {
+  [key: string]: JSONPrimitive | JSONPrimitive[] | JsonRecord;
+};
 
 export interface DocumentWriteParameters {
   dirty_values?: "coerce_or_reject" | "coerce_or_drop" | "drop" | "reject";


### PR DESCRIPTION
## Change Summary
Curated responses can include an arbitrary record of JSON values.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [ ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
