### PR TITLE
add: curation_sets and analytics search event update

### DIFF
--- a/src/Typesense/Client.ts
+++ b/src/Typesense/Client.ts
@@ -27,7 +27,8 @@ import NLSearchModels from "./NLSearchModels";
 import NLSearchModel from "./NLSearchModel";
 import SynonymSets from "./SynonymSets";
 import SynonymSet from "./SynonymSet";
-
+import CurationSets from "./CurationSets";
+import CurationSet from "./CurationSet";
 export default class Client {
   configuration: Configuration;
   apiCall: ApiCall;
@@ -56,6 +57,8 @@ export default class Client {
   private readonly individualNLSearchModels: Record<string, NLSearchModel>;
   private readonly _synonymSets: SynonymSets;
   private readonly individualSynonymSets: Record<string, SynonymSet>;
+  private readonly _curationSets: CurationSets;
+  private readonly individualCurationSets: Record<string, CurationSet>;
 
   constructor(options: ConfigurationOptions) {
     options.sendApiKeyAsQueryParam = options.sendApiKeyAsQueryParam ?? false;
@@ -87,6 +90,8 @@ export default class Client {
     this.individualNLSearchModels = {};
     this._synonymSets = new SynonymSets(this.apiCall);
     this.individualSynonymSets = {};
+    this._curationSets = new CurationSets(this.apiCall);
+    this.individualCurationSets = {};
   }
 
   collections(): Collections;
@@ -199,6 +204,22 @@ export default class Client {
         );
       }
       return this.individualSynonymSets[synonymSetName];
+    }
+  }
+
+  curationSets(): CurationSets;
+  curationSets(name: string): CurationSet;
+  curationSets(name?: string): CurationSets | CurationSet {
+    if (name === undefined) {
+      return this._curationSets;
+    } else {
+      if (this.individualCurationSets[name] === undefined) {
+        this.individualCurationSets[name] = new CurationSet(
+          name,
+          this.apiCall,
+        );
+      }
+      return this.individualCurationSets[name];
     }
   }
 }

--- a/src/Typesense/CurationSet.ts
+++ b/src/Typesense/CurationSet.ts
@@ -1,0 +1,54 @@
+import ApiCall from "./ApiCall";
+import CurationSets, {
+  CurationSetDeleteResponseSchema,
+  CurationSetSchema,
+  CurationSetUpsertSchema,
+} from "./CurationSets";
+import CurationSetItems from "./CurationSetItems";
+import CurationSetItem from "./CurationSetItem";
+
+export default class CurationSet {
+  private readonly _items: CurationSetItems;
+  private individualItems: Record<string, CurationSetItem> = {};
+
+  constructor(private name: string, private apiCall: ApiCall) {
+    this._items = new CurationSetItems(this.name, apiCall);
+  }
+
+  async upsert(params: CurationSetUpsertSchema): Promise<CurationSetSchema> {
+    return this.apiCall.put<CurationSetSchema>(this.endpointPath(), params);
+  }
+
+  async retrieve(): Promise<CurationSetSchema> {
+    return this.apiCall.get<CurationSetSchema>(this.endpointPath());
+  }
+
+  async delete(): Promise<CurationSetDeleteResponseSchema> {
+    return this.apiCall.delete<CurationSetDeleteResponseSchema>(
+      this.endpointPath(),
+    );
+  }
+
+  items(): CurationSetItems;
+  items(itemId: string): CurationSetItem;
+  items(itemId?: string): CurationSetItems | CurationSetItem {
+    if (itemId === undefined) {
+      return this._items;
+    } else {
+      if (this.individualItems[itemId] === undefined) {
+        this.individualItems[itemId] = new CurationSetItem(
+          this.name,
+          itemId,
+          this.apiCall,
+        );
+      }
+      return this.individualItems[itemId];
+    }
+  }
+
+  private endpointPath(): string {
+    return `${CurationSets.RESOURCEPATH}/${encodeURIComponent(this.name)}`;
+  }
+}
+
+

--- a/src/Typesense/CurationSetItem.ts
+++ b/src/Typesense/CurationSetItem.ts
@@ -1,0 +1,36 @@
+import ApiCall from "./ApiCall";
+import CurationSets, { CurationObjectSchema } from "./CurationSets";
+
+export interface CurationItemDeleteResponseSchema {
+  id: string;
+}
+
+export default class CurationSetItem {
+  constructor(
+    private name: string,
+    private itemId: string,
+    private apiCall: ApiCall,
+  ) {}
+
+  async retrieve(): Promise<CurationObjectSchema> {
+    return this.apiCall.get<CurationObjectSchema>(this.endpointPath());
+  }
+
+  async upsert(params: CurationObjectSchema): Promise<CurationObjectSchema> {
+    return this.apiCall.put<CurationObjectSchema>(this.endpointPath(), params);
+  }
+
+  async delete(): Promise<CurationItemDeleteResponseSchema> {
+    return this.apiCall.delete<CurationItemDeleteResponseSchema>(
+      this.endpointPath(),
+    );
+  }
+
+  private endpointPath(): string {
+    return `${CurationSets.RESOURCEPATH}/${encodeURIComponent(
+      this.name,
+    )}/items/${encodeURIComponent(this.itemId)}`;
+  }
+}
+
+

--- a/src/Typesense/CurationSetItems.ts
+++ b/src/Typesense/CurationSetItems.ts
@@ -1,0 +1,18 @@
+import ApiCall from "./ApiCall";
+import CurationSets, { CurationObjectSchema } from "./CurationSets";
+
+export default class CurationSetItems {
+  constructor(private name: string, private apiCall: ApiCall) {}
+
+  async retrieve(): Promise<CurationObjectSchema[]> {
+    return this.apiCall.get<CurationObjectSchema[]>(this.endpointPath());
+  }
+
+  private endpointPath(operation?: string): string {
+    return `${CurationSets.RESOURCEPATH}/${encodeURIComponent(this.name)}/items${
+      operation === undefined ? "" : "/" + encodeURIComponent(operation)
+    }`;
+  }
+}
+
+

--- a/src/Typesense/CurationSets.ts
+++ b/src/Typesense/CurationSets.ts
@@ -1,0 +1,63 @@
+import ApiCall from "./ApiCall";
+
+export interface CurationIncludeSchema {
+  id: string;
+  position: number;
+}
+
+export interface CurationExcludeSchema {
+  id: string;
+}
+
+export interface CurationRuleSchema {
+  query?: string;
+  match?: "exact" | "contains";
+  filter_by?: string;
+  tags?: string[];
+}
+
+export interface CurationObjectSchema {
+  id: string;
+  rule?: CurationRuleSchema;
+  includes?: CurationIncludeSchema[];
+  excludes?: CurationExcludeSchema[];
+  filter_by?: string;
+  sort_by?: string;
+  replace_query?: string;
+  remove_matched_tokens?: boolean;
+  filter_curated_hits?: boolean;
+  stop_processing?: boolean;
+  metadata?: Record<string, unknown>;
+}
+
+export interface CurationSetUpsertSchema {
+  items: CurationObjectSchema[];
+}
+
+export interface CurationSetSchema extends CurationSetUpsertSchema {
+  name?: string;
+}
+
+export interface CurationSetsListEntrySchema {
+  name: string;
+  items: CurationObjectSchema[];
+}
+
+export type CurationSetsListResponseSchema = CurationSetsListEntrySchema[];
+
+export interface CurationSetDeleteResponseSchema {
+  name: string;
+}
+
+export default class CurationSets {
+  constructor(private apiCall: ApiCall) {}
+  static readonly RESOURCEPATH = "/curation_sets";
+
+  async retrieve(): Promise<CurationSetsListResponseSchema> {
+    return this.apiCall.get<CurationSetsListResponseSchema>(
+      CurationSets.RESOURCEPATH,
+    );
+  }
+}
+
+

--- a/test/Typesense/AnalyticsRules.spec.ts
+++ b/test/Typesense/AnalyticsRules.spec.ts
@@ -157,7 +157,7 @@ describe.skipIf(!(await isV30OrAbove(typesense)))("AnalyticsRules", function () 
     name: testRuleName,
     type: "popular_queries",
     collection: "products",
-    event_type: "query",
+    event_type: "search",
     params: {
       destination_collection: "products_top_queries",
       expand_query: true,

--- a/test/Typesense/CurationSetItems.spec.ts
+++ b/test/Typesense/CurationSetItems.spec.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Client as TypesenseClient } from "../../src/Typesense";
+import { ObjectNotFound } from "../../src/Typesense/Errors";
+import { isV30OrAbove } from "../utils";
+
+const typesense = new TypesenseClient({
+  nodes: [
+    {
+      host: "localhost",
+      port: 8108,
+      protocol: "http",
+    },
+  ],
+  apiKey: "xyz",
+  connectionTimeoutSeconds: 180,
+});
+
+describe.skipIf(!(await isV30OrAbove(typesense)))(
+  "CurationSetItems",
+  function () {
+    const testCurationSetName = "test-curation-set-items";
+    const initialData = {
+      items: [
+        {
+          id: "rule-1",
+          rule: {
+            query: "test",
+            match: "exact" as const,
+          },
+          includes: [{ id: "123", position: 1 }],
+        },
+      ],
+    };
+
+    beforeEach(async function () {
+      try {
+        await typesense.curationSets(testCurationSetName).delete();
+      } catch (error) {
+        // ignore
+      }
+    });
+
+    afterEach(async function () {
+      try {
+        await typesense.curationSets(testCurationSetName).delete();
+      } catch (error) {
+        if (!(error instanceof ObjectNotFound)) {
+          console.warn("Failed to cleanup test curation set:", error);
+        }
+      }
+    });
+
+    it("lists items in a curation set", async function () {
+      await typesense.curationSets(testCurationSetName).upsert(initialData);
+
+      const items = await typesense
+        .curationSets(testCurationSetName)
+        .items()
+        .retrieve();
+
+      expect(Array.isArray(items)).toBe(true);
+      expect(items.length).toBeGreaterThan(0);
+      expect(items[0].includes?.[0].id).toBe("123");
+    });
+
+    it("upserts, retrieves and deletes an item", async function () {
+      await typesense.curationSets(testCurationSetName).upsert(initialData);
+
+      const upserted = await typesense
+        .curationSets(testCurationSetName)
+        .items("rule-1")
+        .upsert({ id: "rule-1", rule: { query: "test", match: "exact" as const }, includes: [{ id: "999", position: 1 }] });
+      expect(upserted.id).toBe("rule-1");
+
+      const fetched = await typesense
+        .curationSets(testCurationSetName)
+        .items("rule-1")
+        .retrieve();
+      expect(fetched.includes?.[0].id).toBe("999");
+
+      const deletion = await typesense
+        .curationSets(testCurationSetName)
+        .items("rule-1")
+        .delete();
+      expect(deletion.id).toBe("rule-1");
+    });
+  },
+);
+
+

--- a/test/Typesense/CurationSets.spec.ts
+++ b/test/Typesense/CurationSets.spec.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Client as TypesenseClient } from "../../src/Typesense";
+import { ObjectNotFound } from "../../src/Typesense/Errors";
+import { isV30OrAbove } from "../utils";
+
+const typesense = new TypesenseClient({
+  nodes: [
+    {
+      host: "localhost",
+      port: 8108,
+      protocol: "http",
+    },
+  ],
+  apiKey: "xyz",
+  connectionTimeoutSeconds: 180,
+});
+
+describe.skipIf(!(await isV30OrAbove(typesense)))(
+  "CurationSets",
+  function () {
+    const testCurationSetName = "test-curation-set";
+    const curationSetData = {
+      items: [
+        {
+          id: "rule-1",
+          rule: {
+            query: "test",
+            match: "exact" as const,
+          },
+          includes: [{ id: "123", position: 1 }],
+        },
+      ],
+    };
+
+    beforeEach(async function () {
+      try {
+        await typesense.curationSets(testCurationSetName).delete();
+      } catch (error) {
+        // ignore
+      }
+    });
+
+    afterEach(async function () {
+      try {
+        await typesense.curationSets(testCurationSetName).delete();
+      } catch (error) {
+        if (!(error instanceof ObjectNotFound)) {
+          console.warn("Failed to cleanup test curation set:", error);
+        }
+      }
+    });
+
+    describe(".upsert/.retrieve/.delete", function () {
+      it("creates, retrieves and deletes a curation set", async function () {
+        const upserted = await typesense
+          .curationSets(testCurationSetName)
+          .upsert(curationSetData);
+        expect(upserted.items.length).toBeGreaterThan(0);
+
+        const fetched = await typesense
+          .curationSets(testCurationSetName)
+          .retrieve();
+        expect(fetched.items[0].includes?.[0].id).toBe("123");
+
+        const deletion = await typesense
+          .curationSets(testCurationSetName)
+          .delete();
+        expect(deletion.name).toBe(testCurationSetName);
+      });
+    });
+
+    describe(".list all", function () {
+      it("retrieves all curation sets", async function () {
+        await typesense.curationSets(testCurationSetName).upsert(curationSetData);
+
+        const all = await typesense.curationSets().retrieve();
+        expect(Array.isArray(all)).toBe(true);
+        const created = all.find((c) => c.name === testCurationSetName);
+        expect(created).toBeDefined();
+      });
+    });
+  },
+);
+
+

--- a/test/Typesense/Override.spec.ts
+++ b/test/Typesense/Override.spec.ts
@@ -2,19 +2,20 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Client as TypesenseClient } from "../../src/Typesense";
 import { ObjectNotFound } from "../../src/Typesense/Errors";
 import { OverrideCreateSchema } from "../../src/Typesense/Overrides";
+import { isV30OrAbove } from "../utils";
 
-describe("Override", function () {
-  const typesense = new TypesenseClient({
-    nodes: [
-      {
-        host: "localhost",
-        port: 8108,
-        protocol: "http",
-      },
-    ],
-    apiKey: "xyz",
-    connectionTimeoutSeconds: 180,
-  });
+const typesense = new TypesenseClient({
+  nodes: [
+    {
+      host: "localhost",
+      port: 8108,
+      protocol: "http",
+    },
+  ],
+  apiKey: "xyz",
+  connectionTimeoutSeconds: 180,
+});
+describe.skipIf((await isV30OrAbove(typesense)))("Override", function () {
 
   const testCollectionName = "test_companies_override";
   const testOverrideId = "lex-exact";

--- a/test/Typesense/Overrides.spec.ts
+++ b/test/Typesense/Overrides.spec.ts
@@ -2,20 +2,20 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Client as TypesenseClient } from "../../src/Typesense";
 import { ObjectNotFound } from "../../src/Typesense/Errors";
 import { OverrideCreateSchema } from "../../src/Typesense/Overrides";
+import { isV30OrAbove } from "../utils";
 
-describe("Overrides", function () {
-  const typesense = new TypesenseClient({
-    nodes: [
-      {
-        host: "localhost",
-        port: 8108,
-        protocol: "http",
-      },
-    ],
-    apiKey: "xyz",
-    connectionTimeoutSeconds: 180,
-  });
-
+const typesense = new TypesenseClient({
+  nodes: [
+    {
+      host: "localhost",
+      port: 8108,
+      protocol: "http",
+    },
+  ],
+  apiKey: "xyz",
+  connectionTimeoutSeconds: 180,
+});
+describe.skipIf((await isV30OrAbove(typesense)))("Overrides", function () {
   const testCollectionName = "test_companies_overrides";
   const testOverrideId = "lex-exact";
   const overrideData: OverrideCreateSchema = {


### PR DESCRIPTION
## Change Summary
- Added: Curation Sets API (requires Typesense server v30+)
  - New client entrypoints: `client.curationSets()` and `client.curationSets(name)`
  - Endpoints supported:
    - List all: `curationSets().retrieve()`
    - Upsert: `curationSets(name).upsert({ items: [...] })`
    - Retrieve: `curationSets(name).retrieve()`
    - Delete: `curationSets(name).delete()`
    - Items:
      - List: `curationSets(name).items().retrieve()`
      - Get: `curationSets(name).items(id).retrieve()`
      - Upsert: `curationSets(name).items(id).upsert({...})`
      - Delete: `curationSets(name).items(id).delete()`
  - Notes:
    - Tests are gated with a version check and run only on Typesense v30+.
    - No breaking changes.

- Added: Synonym Set Items sub-API
  - List items: `synonymSets(name).items().retrieve()`
  - Get/Upsert/Delete single item: `synonymSets(name).items(id).{retrieve,upsert,delete}()`

### Usage examples

```ts
// Curation Sets (Typesense v30+)
const typesense = new Typesense.Client({
  nodes: [{ host: "localhost", port: 8108, protocol: "http" }],
  apiKey: "xyz",
});

// Upsert a curation set
await typesense.curationSets("promotions").upsert({
  items: [
    {
      id: "rule-1",
      rule: { query: "test", match: "exact" },
      includes: [{ id: "123", position: 1 }],
    },
  ],
});

// Retrieve a curation set
const curation = await typesense.curationSets("promotions").retrieve();

// List all curation sets
const all = await typesense.curationSets().retrieve();

// List items in a set
const items = await typesense.curationSets("promotions").items().retrieve();

// Upsert a single item
await typesense
  .curationSets("promotions")
  .items("rule-1")
  .upsert({ id: "rule-1", rule: { query: "test", match: "exact" }, includes: [{ id: "999", position: 1 }] });

// Get a single item
const item = await typesense.curationSets("promotions").items("rule-1").retrieve();

// Delete a single item
await typesense.curationSets("promotions").items("rule-1").delete();

// Delete the curation set
await typesense.curationSets("promotions").delete();
```

```ts
// Synonym Set Items
// List items
await typesense.synonymSets("colors").items().retrieve();

// Upsert one item
await typesense
  .synonymSets("colors")
  .items("color-item")
  .upsert({ synonyms: ["blue", "azure"] });

// Get one item
await typesense.synonymSets("colors").items("color-item").retrieve();

// Delete one item
await typesense.synonymSets("colors").items("color-item").delete();
```

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
