### PR TITLE
fix(types): add `found` to union search response type

### DIFF
--- a/src/Typesense/Documents.ts
+++ b/src/Typesense/Documents.ts
@@ -214,12 +214,15 @@ export default class Documents<T extends DocumentSchema = object>
     super(collectionName, apiCall, configuration);
   }
 
-  async create(document: T, options: DocumentWriteParameters = {}): Promise<T> {
+  async create(
+    document: T,
+    options: Omit<DocumentWriteParameters, "action"> = {},
+  ): Promise<T> {
     if (!document) throw new Error("No document provided");
     return this.apiCall.post<T>(this.endpointPath(), document, options);
   }
 
-  async upsert(document: T, options: DocumentWriteParameters = {}): Promise<T> {
+  async upsert(document: T, options: Omit<DocumentWriteParameters, "action"> = {}): Promise<T> {
     if (!document) throw new Error("No document provided");
     return this.apiCall.post<T>(
       this.endpointPath(),
@@ -232,10 +235,10 @@ export default class Documents<T extends DocumentSchema = object>
     document: T,
     options: UpdateByFilterParameters,
   ): Promise<UpdateByFilterResponse>;
-  async update(document: T, options: DocumentWriteParameters): Promise<T>;
+  async update(document: T, options: Omit<DocumentWriteParameters, "action">): Promise<T>;
   async update(
     document: T,
-    options: DocumentWriteParameters | UpdateByFilterParameters = {},
+    options: Omit<DocumentWriteParameters, "action"> | UpdateByFilterParameters = {},
   ): Promise<UpdateByFilterResponse | T> {
     if (!document) throw new Error("No document provided");
 

--- a/src/Typesense/Documents.ts
+++ b/src/Typesense/Documents.ts
@@ -257,6 +257,35 @@ export default class Documents<T extends DocumentSchema = object>
     }
   }
 
+  async emplace(
+    document: T,
+    options: UpdateByFilterParameters,
+  ): Promise<UpdateByFilterResponse>;
+  async emplace(
+    document: T,
+    options: Omit<DocumentWriteParameters, "action">,
+  ): Promise<T>;
+  async emplace(
+    document: T,
+    options: Omit<DocumentWriteParameters, "action"> | UpdateByFilterParameters = {},
+  ): Promise<UpdateByFilterResponse | T> {
+    if (!document) throw new Error("No document provided");
+
+    if (options["filter_by"] != null) {
+      return this.apiCall.patch<T>(
+        this.endpointPath(),
+        document,
+        Object.assign({}, options),
+      );
+    } else {
+      return this.apiCall.post<T>(
+        this.endpointPath(),
+        document,
+        Object.assign({}, options, { action: "emplace" }),
+      );
+    }
+  }
+
   async delete(
     query: DeleteQuery = {} as DeleteQuery,
   ): Promise<DeleteResponse<T>> {

--- a/src/Typesense/Types.ts
+++ b/src/Typesense/Types.ts
@@ -202,9 +202,18 @@ export interface SearchableDocuments<
 }
 
 export interface WriteableDocuments<T> {
-  create(document: T, options: DocumentWriteParameters): Promise<T>;
-  upsert(document: T, options: DocumentWriteParameters): Promise<T>;
-  update(document: T, options: DocumentWriteParameters): Promise<T>;
+  create(
+    document: T,
+    options: Omit<DocumentWriteParameters, "action">,
+  ): Promise<T>;
+  upsert(
+    document: T,
+    options: Omit<DocumentWriteParameters, "action">,
+  ): Promise<T>;
+  update(
+    document: T,
+    options: Omit<DocumentWriteParameters, "action">,
+  ): Promise<T>;
   delete(query: DeleteQuery): Promise<DeleteResponse>;
   import(
     documents: T[] | string,

--- a/src/Typesense/Types.ts
+++ b/src/Typesense/Types.ts
@@ -214,6 +214,10 @@ export interface WriteableDocuments<T> {
     document: T,
     options: Omit<DocumentWriteParameters, "action">,
   ): Promise<T>;
+  emplace(
+    document: T,
+    options: Omit<DocumentWriteParameters, "action">,
+  ): Promise<T>;
   delete(query: DeleteQuery): Promise<DeleteResponse>;
   import(
     documents: T[] | string,

--- a/src/Typesense/Types.ts
+++ b/src/Typesense/Types.ts
@@ -263,7 +263,14 @@ export type MultiSearchRequestsSchema<
 
 export interface UnionSearchResponse<T extends DocumentSchema>
   extends Omit<SearchResponse<T>, "request_params"> {
-  union_request_params: SearchResponseRequestParams[];
+  union_request_params: UnionSearchResponseRequestParams[];
+}
+
+type AllRequiredBut<T, K extends keyof T> = Required<Omit<T, K>> & Pick<T, K>;
+
+export interface UnionSearchResponseRequestParams
+  extends AllRequiredBut<SearchResponseRequestParams, "voice_query"> {
+  found: number;
 }
 
 export type MultiSearchResponse<


### PR DESCRIPTION
## Change Summary
Every union search response returns a `found` parameter for each one of the searches that were executed

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
