### PR TITLE
feat: add dedicated emplace function for documents and remove type hints for actions on write functions

### DIFF
--- a/src/Typesense/Documents.ts
+++ b/src/Typesense/Documents.ts
@@ -257,6 +257,35 @@ export default class Documents<T extends DocumentSchema = object>
     }
   }
 
+  async emplace(
+    document: T,
+    options: UpdateByFilterParameters,
+  ): Promise<UpdateByFilterResponse>;
+  async emplace(
+    document: T,
+    options: Omit<DocumentWriteParameters, "action">,
+  ): Promise<T>;
+  async emplace(
+    document: T,
+    options: Omit<DocumentWriteParameters, "action"> | UpdateByFilterParameters = {},
+  ): Promise<UpdateByFilterResponse | T> {
+    if (!document) throw new Error("No document provided");
+
+    if (options["filter_by"] != null) {
+      return this.apiCall.patch<T>(
+        this.endpointPath(),
+        document,
+        Object.assign({}, options),
+      );
+    } else {
+      return this.apiCall.post<T>(
+        this.endpointPath(),
+        document,
+        Object.assign({}, options, { action: "emplace" }),
+      );
+    }
+  }
+
   async delete(
     query: DeleteQuery = {} as DeleteQuery,
   ): Promise<DeleteResponse<T>> {

--- a/src/Typesense/Types.ts
+++ b/src/Typesense/Types.ts
@@ -214,6 +214,10 @@ export interface WriteableDocuments<T> {
     document: T,
     options: Omit<DocumentWriteParameters, "action">,
   ): Promise<T>;
+  emplace(
+    document: T,
+    options: Omit<DocumentWriteParameters, "action">,
+  ): Promise<T>;
   delete(query: DeleteQuery): Promise<DeleteResponse>;
   import(
     documents: T[] | string,


### PR DESCRIPTION
## Change Summary
- Add dedicated emplace function for single writes
- Don't let users define the action type of a function when it's being overridden afterwards by `Object.assign`.
- Closes #313 

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
