### PR TITLE
fix: add ability to include/exclude fields for a single document

### DIFF
--- a/src/Typesense/Document.ts
+++ b/src/Typesense/Document.ts
@@ -5,6 +5,12 @@ import Documents, {
   DocumentSchema,
   DocumentWriteParameters,
 } from "./Documents";
+import { normalizeArrayableParams } from "./Utils";
+
+export interface DocumentsRetrieveParameters {
+  include_fields?: string | string[];
+  exclude_fields?: string | string[];
+}
 
 export class Document<T extends DocumentSchema = object> {
   constructor(
@@ -13,8 +19,10 @@ export class Document<T extends DocumentSchema = object> {
     private apiCall: ApiCall
   ) {}
 
-  async retrieve(): Promise<T> {
-    return this.apiCall.get<T>(this.endpointPath());
+  async retrieve(options?: DocumentsRetrieveParameters): Promise<T> {
+    const queryParams = normalizeArrayableParams(options ?? {})
+    
+    return this.apiCall.get<T>(this.endpointPath(), queryParams);
   }
 
   async delete(options?: DeleteQuery): Promise<T> {


### PR DESCRIPTION
## Change Summary
Added optional `options` parameter to `Document.retrieve()` method. The new parameter includes `include_fields` and `exclude_fields` options, which are being passed to the api client as query parameters.
Resolves #325

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
