### PR TITLE
fix(multisearch): fix cache handling regression

### DIFF
--- a/src/Typesense/MultiSearch.ts
+++ b/src/Typesense/MultiSearch.ts
@@ -72,6 +72,9 @@ export default class MultiSearch {
     options?: SearchOptions,
   ): Promise<MultiSearchResponse<T, Infix>> {
     const params = commonParams ? { ...commonParams } : {};
+    const cacheSearchResultsForSeconds =
+      options?.cacheSearchResultsForSeconds ??
+      this.configuration.cacheSearchResultsForSeconds;
 
     if (this.configuration.useServerSideSearchCache === true) {
       params.use_cache = true;
@@ -115,8 +118,8 @@ export default class MultiSearch {
         abortSignal: options?.abortSignal,
         isStreamingRequest: this.isStreamingRequest(params),
       },
-      options?.cacheSearchResultsForSeconds !== undefined
-        ? { cacheResponseForSeconds: options.cacheSearchResultsForSeconds }
+      cacheSearchResultsForSeconds !== undefined
+        ? { cacheResponseForSeconds: cacheSearchResultsForSeconds }
         : undefined,
     );
   }

--- a/test/Typesense/SearchClient.spec.ts
+++ b/test/Typesense/SearchClient.spec.ts
@@ -179,4 +179,25 @@ describe("SearchClient", function () {
     // if 2 requests are made, then we know that cache was cleared successfully
     expect(mockAxios.history["post"].length).toBe(2);
   });
+
+  it("should cache multi_search requests using client configuration by default", async function () {
+    const searchRequest = {
+      searches: [{ q: "term1" }, { q: "term2" }],
+    };
+    const commonParams = {
+      collection: "docs",
+      query_by: "field",
+    };
+
+    mockAxios
+      .onPost("http://node0:8108/multi_search")
+      .reply(200, JSON.stringify({ results: [] }), {
+        "content-type": "application/json",
+      });
+
+    await typesense.multiSearch.perform(searchRequest, commonParams);
+    await typesense.multiSearch.perform(searchRequest, commonParams);
+
+    expect(mockAxios.history["post"].length).toBe(1);
+  });
 });


### PR DESCRIPTION
## Change Summary
Restores `multiSearch.perform` cache fallback to `configuration.cacheSearchResultsForSeconds`, because [adapter](https://github.com/typesense/typesense-instantsearch-adapter/issues/264) and other 2-arg callers lost client-side caching after that fallback got removed.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [ ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
