### PR TITLE
Fix/curation set types

### DIFF
--- a/src/Typesense/Collection.ts
+++ b/src/Typesense/Collection.ts
@@ -66,6 +66,7 @@ export interface CollectionUpdateSchema
   extends Partial<Omit<CollectionCreateSchema, "name" | "fields">> {
   fields?: (CollectionFieldSchema | CollectionDropFieldSchema)[];
   synonym_sets?: string[];
+  curation_sets?: string[];
 }
 
 export interface CollectionDeleteOptions {

--- a/src/Typesense/Collection.ts
+++ b/src/Typesense/Collection.ts
@@ -65,8 +65,6 @@ export interface CollectionDropFieldSchema {
 export interface CollectionUpdateSchema
   extends Partial<Omit<CollectionCreateSchema, "name" | "fields">> {
   fields?: (CollectionFieldSchema | CollectionDropFieldSchema)[];
-  synonym_sets?: string[];
-  curation_sets?: string[];
 }
 
 export interface CollectionDeleteOptions {

--- a/src/Typesense/CurationSetItem.ts
+++ b/src/Typesense/CurationSetItem.ts
@@ -2,6 +2,8 @@ import ApiCall from "./ApiCall";
 import CurationSets from "./CurationSets";
 import type { CurationObjectSchema } from "./CurationSets";
 
+export type CurationItemUpsertSchema = Omit<CurationObjectSchema, "id">;
+
 export interface CurationItemDeleteResponseSchema {
   id: string;
 }
@@ -17,7 +19,9 @@ export default class CurationSetItem {
     return this.apiCall.get<CurationObjectSchema>(this.endpointPath());
   }
 
-  async upsert(params: CurationObjectSchema): Promise<CurationObjectSchema> {
+  async upsert(
+    params: CurationItemUpsertSchema,
+  ): Promise<CurationObjectSchema> {
     return this.apiCall.put<CurationObjectSchema>(this.endpointPath(), params);
   }
 


### PR DESCRIPTION
## Change Summary

Fix two missing type definitions for curation set support in Typesense v30:

1. CollectionUpdateSchema missing curation_sets — `synonym_sets` was explicitly
   added but `curation_sets` was not, even though `BaseCollectionCreateSchema` already
   defines both. This forces consumers to extend the interface locally to call
   `collection.update({ curation_sets: [...] })`. The
   https://typesense.org/docs/30.0/api/curation.html confirm `curation_sets` is
   supported on collection PATCH.

2. CurationSetItem.upsert() requires id in the body — The upsert endpoint is PUT
   `/curation_sets/:name/items/:id`, so id lives in the URL path. But the method
   requires `CurationObjectSchema` which has id as mandatory, forcing as unknown as
   casts. Introduced `CurationItemUpsertSchema (Omit<CurationObjectSchema, "id">)` to
   align the SDK with the https://typesense.org/docs/30.0/api/curation.html.

## PR Checklist

- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
      Change Summary