### PR TITLE
fix(types): use collection field in UnionSearchResponseRequestParams

### DIFF
--- a/src/Typesense/Types.ts
+++ b/src/Typesense/Types.ts
@@ -282,7 +282,11 @@ export interface UnionSearchResponse<T extends DocumentSchema>
 type AllRequiredBut<T, K extends keyof T> = Required<Omit<T, K>> & Pick<T, K>;
 
 export interface UnionSearchResponseRequestParams
-  extends AllRequiredBut<SearchResponseRequestParams, "voice_query"> {
+  extends Omit<
+    AllRequiredBut<SearchResponseRequestParams, "voice_query">,
+    "collection_name"
+  > {
+  collection: string;
   found: number;
 }
 


### PR DESCRIPTION
Fixes #321.

`UnionSearchResponseRequestParams` extends `SearchResponseRequestParams`, which declares `collection_name?: string`. But for a union multi-search, the server returns the per-search entry under `union_request_params` with the field named `collection` (matching the field name used in the request), not `collection_name`. The current type forces callers to widen or cast every time they read `union_request_params[i].collection`.

Override the field on the union variant: omit `collection_name` from the inherited shape and add `collection: string`. Regular `SearchResponseRequestParams` (used by `SearchResponse.request_params`) is unchanged.

Confirmed against the response shape from the issue:

```json
{
  "union_request_params": [
    { "collection": "collection_one", "first_q": "test", "found": 30, ... }
  ]
}
```

No runtime code touched; this is types-only.